### PR TITLE
Minuit integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
   # Download numpy and matplotlib binaries from binstar
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas iminuit
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas
   # Setup coverage for converage measurement
   - pip install coverage
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 install:
   # Download numpy and matplotlib binaries from binstar
   - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas
+  - conda install -c astropy iminuit
   # Setup coverage for converage measurement
   - pip install coverage
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
   # Download numpy and matplotlib binaries from binstar
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas iminuit
   # Setup coverage for converage measurement
   - pip install coverage
   - pip install coveralls

--- a/blueice/inference.py
+++ b/blueice/inference.py
@@ -241,7 +241,9 @@ def one_parameter_interval(lf, target, bound,
         return brentq(t, global_best, bound, args=[confidence_level])
 
 
-def plot_likelihood_ratio(lf, *space, vmax=15, plot_kwargs=None, **kwargs):
+def plot_likelihood_ratio(lf, *space, vmax=15,
+                          bestfit_routine=bestfit_scipy,
+                          plot_kwargs=None, **kwargs):
     """Plots the loglikelihood ratio derived from LogLikelihood lf in a parameter space
     :param lf: LogLikelihood function with data set.
     :param space: list/tuple of tuples (dimname, points to plot)
@@ -259,7 +261,7 @@ def plot_likelihood_ratio(lf, *space, vmax=15, plot_kwargs=None, **kwargs):
         for q in x:
             lf_kwargs = {dim: q}
             lf_kwargs.update(kwargs)
-            results.append(bestfit_scipy(lf, **lf_kwargs)[1])
+            results.append(bestfit_routine(lf, **lf_kwargs)[1])
         results = np.array(results)
         results = results.max() - results
         plt.plot(x, results, **plot_kwargs)
@@ -276,7 +278,7 @@ def plot_likelihood_ratio(lf, *space, vmax=15, plot_kwargs=None, **kwargs):
             for z2 in y:
                 lf_kwargs = {dims[0]: z1, dims[1]: z2}
                 lf_kwargs.update(kwargs)
-                results[-1].append(bestfit_scipy(lf, **lf_kwargs)[1])
+                results[-1].append(bestfit_routine(lf, **lf_kwargs)[1])
         z1, z2 = np.meshgrid(x, y)
         results = np.array(results)
         results = results.max() - results

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ scipy>=0.15
 tqdm                 # Progress bar library
 multihist>=0.4.1     # Histogram library
 pytest>=3.0.0        # 3.0 needed for a yield statement in a fixture
-iminuit              # The Minuit minimizer
+
+# Not required, but recommended:
+# iminuit              # The Minuit minimizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scipy>=0.15
 tqdm                 # Progress bar library
 multihist>=0.4.1     # Histogram library
 pytest>=3.0.0        # 3.0 needed for a yield statement in a fixture
+iminuit              # The Minuit minimizer

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4,6 +4,47 @@ from blueice.likelihood import LogLikelihood
 import matplotlib.pyplot as plt
 from scipy import stats
 
+
+def test_fit_minuit():
+    # Single rate parameter
+    lf = LogLikelihood(test_conf())
+    lf.add_rate_parameter('s0')
+    lf.set_data(lf.base_model.simulate())
+    fit_result, ll = bestfit_minuit(lf)
+    assert isinstance(fit_result, dict)
+    assert 's0_rate_multiplier' in fit_result
+
+    # Don't fit
+    res, ll = bestfit_minuit(lf, s0_rate_multiplier=1)
+    assert len(res) == 0
+    assert ll == lf(s0_rate_multiplier=1)
+
+    # Single shape parameter
+    lf = LogLikelihood(test_conf())
+    lf.add_shape_parameter('some_multiplier', (0.5, 1, 1.5, 2))
+    lf.prepare()
+    lf.set_data(lf.base_model.simulate())
+    fit_result, ll = bestfit_minuit(lf)
+    assert 'some_multiplier' in fit_result
+
+    # Shape and rate parameter
+    lf = LogLikelihood(test_conf())
+    lf.add_rate_parameter('s0')
+    lf.add_shape_parameter('some_multiplier', (0.5, 1, 1.5, 2))
+    lf.prepare()
+    lf.set_data(lf.base_model.simulate())
+    fit_result, ll = bestfit_minuit(lf)
+    assert 'some_multiplier' in fit_result
+    assert 's0_rate_multiplier' in fit_result
+
+    # Non-numeric shape parameter
+    lf = LogLikelihood(test_conf())
+    lf.add_shape_parameter('strlen_multiplier', {1: 'x', 2: 'hi', 3:'wha'}, base_value=1)
+    lf.prepare()
+    lf.set_data(lf.base_model.simulate())
+    fit_result, ll = bestfit_minuit(lf)
+    assert 'strlen_multiplier' in fit_result
+
 def test_fit_scipy():
     # Single rate parameter
     lf = LogLikelihood(test_conf())


### PR DESCRIPTION
This implements integration of the Minuit minimizer via the iminuit package. 
Currently 'bestfit_minuit'  provides the same functionality as the 'bestfit_scipy' function ('bestfit_scipy' is still the default).
Minuit can be used by setting the 'bestfit_routine' parameter in  'plot_likelihood_ratio'  or 'one_parameter_interval' to 'bestfit_minuit'.

This addresses/solves issue #10 