### PR TITLE
Likelihood sum wrapper and negative events

### DIFF
--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -269,7 +269,7 @@ class LogLikelihoodBase(object):
                 else:
                     return -float('inf')
         else:
-            if not any(mus < float('inf')):
+            if (not any(mus < float('inf'))) or (np.sum(mus)<0):
                 if self.config.get('unphysical_behaviour') == 'error':
                     raise ValueError("Unphysical rates: %s" % str(mus))
                 else:
@@ -617,6 +617,21 @@ class LogLikelihoodSum(object):
     #def make_objective(self, guess=None, minus=True, rates_in_log_space=False, **kwargs):
     #    return make_objective(self, guess,minus,rates_in_log_space,**kwargs)
     
+class LogAncillaryLikelihood(object):
+    def __init__(self, mu_name, sigma_value):
+        self.rate_parameters = dict()
+        self.shape_parameters = dict()
+        self.source_list = [] # DOES NOT EXIST IN LF!
+        #in order to pass to confidence interval
+        self.pdf_base_config  ={}#might also have to be fudged
+
+        self.sigma_value = sigma_value
+
+
+        self.shape_parameters.update(OrderedDict(mu_name,(None,None,None)))
+
+
+
 # Add the inference methods from .inference
 for methodname in inference.__all__:
     setattr(LogLikelihoodSum, methodname, getattr(inference, methodname))

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -531,7 +531,7 @@ def beeston_barlow_root2(a, p, U, d):
 def beeston_barlow_roots(a, p, U, d):
     return beeston_barlow_root1(a, p, U, d), beeston_barlow_root2(a, p, U, d)
 
-class LogLikelihoodSum(Object):
+class LogLikelihoodSum(object):
     """
         Class that takes a list of likelihoods to be minimized together, and 
         provides an interface to the inference methods and evaluation similar to likelihoods. 

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -20,7 +20,7 @@ from .pdf_morphers import MORPHERS
 from .utils import combine_dicts, inherit_docstring_from
 from . import inference
 
-__all__ = ['LogLikelihoodBase', 'BinnedLogLikelihood', 'UnbinnedLogLikelihood']
+__all__ = ['LogLikelihoodBase', 'BinnedLogLikelihood', 'UnbinnedLogLikelihood', 'loglikelihood_sum']
 
 
 ##
@@ -530,3 +530,67 @@ def beeston_barlow_root2(a, p, U, d):
 
 def beeston_barlow_roots(a, p, U, d):
     return beeston_barlow_root1(a, p, U, d), beeston_barlow_root2(a, p, U, d)
+
+class LogLikelihoodSum(Object):
+    """
+        Class that takes a list of likelihoods to be minimized together, and 
+        provides an interface to the inference methods and evaluation similar to likelihoods. 
+        Note that the pfd_base_config is a bit of a fudge; only storing guesses from the last likelihood. 
+        As different guesses for different likelihoods should be a cause for concern, the safest method is to pass
+        manual guesses to the minimization. 
+    """
+    def __init__(self, likelihood_list):
+        self.likelihood_list = []
+        self.rate_parameters = dict()
+        self.shape_parameters = dict()
+        self.source_list = [] # DOES NOT EXIST IN LF!
+        #in order to pass to confidence interval
+        self.pdf_base_config  ={}#might also have to be fudged
+        
+        
+        for ll in likelihood_list:
+            self.likelihood_list.append(ll)
+            self.rate_parameters.update(ll.rate_parameters)
+            self.shape_parameters.update(ll.shape_parameters)
+            
+            for rate_parameter_name in ll.rate_parameters.keys():
+                base_value = ll.pdf_base_config.get(rate_parameter_name)
+                if base_value is not None:
+                    self.pdf_base_config[rate_parameter_name] = base_value
+            for shape_parameter_name in ll.shape_parameters.keys():
+                base_value = ll.pdf_base_config.get(shape_parameter_name)
+                if base_value is not None:
+                    self.pdf_base_config[shape_parameter_name] = base_value
+                
+    
+    def __call__(self,livetime_days=None, **kwargs):
+        ret = 0.
+        for ll in self.likelihood_list:
+            ret += ll(livetime_days=livetime_days, **kwargs)
+        return ret
+    def get_bounds(self, parameter_name=None):
+        """Return bounds on the parameter parameter_name"""
+        if parameter_name is None:
+            return [self.get_bounds(p) for p in self.shape_parameters]
+        if parameter_name in self.shape_parameters.keys():
+            bounds = []
+            for ll in self.likelihood_list:
+                if parameter_name in ll.shape_parameters.keys():
+                    bounds.append(ll.get_bounds(parameter_name))
+            bounds = np.array(bounds)
+            ret= np.max(bounds[:,0]), np.min(bounds[:,1])
+            if ret[1] <= ret[0]:
+                raise InvalidParameterSpecification("lower bound %s higher than upper bound!"%parameter_name)
+            return ret
+            
+        elif parameter_name.endswith('_rate_multiplier'):
+            return 0, float('inf')
+        else:
+            raise InvalidParameter("Non-existing parameter %s" % parameter_name)
+    #def make_objective(self, guess=None, minus=True, rates_in_log_space=False, **kwargs):
+    #    return make_objective(self, guess,minus,rates_in_log_space,**kwargs)
+    
+# Add the inference methods from .inference
+for methodname in inference.__all__:
+    setattr(LogLikelihoodSum, methodname, getattr(inference, methodname))
+   

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -20,7 +20,7 @@ from .pdf_morphers import MORPHERS
 from .utils import combine_dicts, inherit_docstring_from
 from . import inference
 
-__all__ = ['LogLikelihoodBase', 'BinnedLogLikelihood', 'UnbinnedLogLikelihood', 'loglikelihood_sum']
+__all__ = ['LogLikelihoodBase', 'BinnedLogLikelihood', 'UnbinnedLogLikelihood', 'LogLikelihoodSum']
 
 
 ##


### PR DESCRIPTION
This branch adds 
-a LogLikelihoodSum wrapper that takes multiple LogLikelihood objects and can be passed to optimisers, inference methods to compute combined fits. 
-by setting the flag allowed_negative for a source, a rate multiplier for this source will be allowed to be negative. Checks for positive rates are bypassed for this source, while the total rate must still be positive. Setting the outlier_likelihood forces the "local" pdf to be positive at each data-point. So far, this has been written only for unbinned likelihoods. 
