### PR TITLE
Remote/parallel model computation without ipyparallel, bestfit_emcee

### DIFF
--- a/bin/bluethaw
+++ b/bin/bluethaw
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+from blueice import compute_all
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', default='.',
+                        help="Directory to read source computation task files from")
+    parser.add_argument('--output', default='./pdf_cache',
+                        help="Directory to write source PDFs to")
+    parser.add_argument('--n_cpus', default=1,
+                        help="Number of CPUs to use for computation")
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.output):
+        print("Creating output directory %s" % args.output)
+        os.makedirs(args.output)
+
+    compute_all(args.input, result_dir=args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/blueice/__init__.py
+++ b/blueice/__init__.py
@@ -1,8 +1,10 @@
 # Put core functionality at top level
 # Modules below all have __all__ defined to make sure 'from ... import *' is well-behaved
+# (well, exceptions does not, but it contains no shenanigans)
 from .likelihood import *
 from .model import *
 from .source import *
+from .exceptions import *
 # from .inference import *   # Not needed, all the inference methods are added to LogLikelihood
 from .parallel import *
 

--- a/blueice/inference.py
+++ b/blueice/inference.py
@@ -28,7 +28,8 @@ except ImportError:
                   "conda install -c astropy iminuit")
     DEFAULT_BESTFIT_ROUTINE = 'scipy'
 
-__all__ = ['make_objective', 'bestfit_scipy', 'bestfit_minuit', 'plot_likelihood_ratio', 'one_parameter_interval']
+__all__ = ['make_objective', 'bestfit_scipy', 'bestfit_minuit', 'plot_likelihood_ratio', 'one_parameter_interval',
+           'bestfit_emcee']
 
 
 def make_objective(lf, guess=None, minus=True, rates_in_log_space=False, **kwargs):
@@ -208,6 +209,79 @@ def bestfit_minuit(lf, minimize_kwargs=None, rates_in_log_space=False, **kwargs)
     # TODO return more information, such as m.errors
 
     return m.values, -1*m.fval  # , m.errors
+
+
+# Must be defined outside bestfit_emcee to avoid pickling error
+# TODO: will inevitably create problems, globals are bad...
+def _lnprob(x):
+    _lnprob.t.update(1)
+    return _lnprob.f(x)
+
+
+def bestfit_emcee(ll, quiet=False, return_errors=False,
+                  n_walkers=40, n_steps=200, n_burn_in=100, n_threads=1,
+                  **kwargs):
+    """Optimize the loglikelihood function ll using emcee's MCMC.
+    The starting position of the walkers is [0.95, 1.05] * the default values / any guess you put in.
+    So if your default value is 0 you have to put in a custom guess. (TODO: fix this)
+
+    :param ll: LogLikelihood to optimize
+    :param quiet: if False (default), show corner plot and print out passthrough info
+    :param return_errors: if True, return a third result, dictionary with 1 sigma errors for each parameter
+    :param n_walkers: Number of walkers to use for the MCMC
+    :param n_steps: Number of steps to use for MCMC
+    :param n_burn_in: Number of burn-in steps to use. These are added to n_steps but thrown away.
+    :param n_threads: Number of concurrent threads to use
+    :param kwargs: Passed to ll.make_objective.
+    :return:
+    """
+    import emcee
+
+    f, names, guess, _  = ll.make_objective(minus=False, **kwargs)
+
+    n_dim = len(guess)
+
+    # Hack to show a progress bar during the computation
+    _lnprob.f = f
+    _lnprob.t = tqdm(desc='Computing likelihoods',
+                    total=n_walkers * n_steps / n_threads)
+
+    # Run the MCMC sampler
+    p0 = np.array([np.random.uniform(0.95, 1.05, size=n_dim)  * guess for i in range(n_walkers)])
+    sampler = emcee.EnsembleSampler(n_walkers, n_dim, _lnprob, threads=n_threads)
+    sampler.run_mcmc(p0, n_steps)
+
+    # Remove first n_burn_in samples for each walker (burn-in)
+    samples = sampler.chain[:, n_burn_in:, :].reshape((-1, n_dim))
+
+    if not quiet:
+        import corner
+        import matplotlib.pyplot as plt
+
+        # "This number should be between approximately 0.25 and 0.5 if everything went as planned"
+        # http://dan.iel.fm/emcee/current/user/quickstart/
+        print("Mean acceptance fraction: {0:.3f}".format(np.mean(sampler.acceptance_fraction)))
+
+        samples = sampler.chain.reshape((-1, n_dim))
+        corner.corner(samples, show_titles=True, labels=names,
+                      range=[0.99] * len(names),
+                      truths=guess,
+        )
+        plt.show()
+
+    fit_result = np.median(samples, axis=0)
+    fit_result_dict = {names[i]: fit_result[i] for i in range(len(names))}
+
+    best_ll = ll(**fit_result_dict)
+
+    if return_errors:
+        l, r = np.percentile(samples, 100 * stats.norm.cdf([-1, 1]), axis=0)
+        fit_errors = (r - l)/2
+        fit_errors_dict = {names[i]: fit_errors[i] for i in range(len(names))}
+
+        return fit_result_dict, best_ll, fit_errors_dict
+
+    return fit_result_dict, best_ll
 
 
 def _get_bestfit_routine(key):

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -15,7 +15,7 @@ from scipy.special import gammaln
 
 from .exceptions import NotPreparedException, InvalidParameterSpecification, InvalidParameter
 from .model import Model
-from .parallel import create_models_ipyparallel
+from .parallel import create_models_ipyparallel, compute_many
 from .pdf_morphers import MORPHERS
 from .utils import combine_dicts, inherit_docstring_from
 from . import inference
@@ -100,7 +100,7 @@ class LogLikelihoodBase(object):
         self.n_model_events_interpolator = lambda x: None
         self.n_model_events = None
 
-    def prepare(self, ipp_client=None):
+    def prepare(self, n_cores=1, ipp_client=None):
         """Prepares a likelihood function with shape parameters for use.
         This will compute the models for each shape parameter anchor value combination.
         """
@@ -116,11 +116,27 @@ class LogLikelihoodBase(object):
                 for i, (setting_name, (anchors, _, _)) in enumerate(self.shape_parameters.items()):
                     # Translate from zs to settings using the anchors dict. Maybe not all settings are numerical.
                     config[setting_name] = anchors[zs[i]]
+                if ipp_client is None:
+                    config['delay_pdf_computation'] = True     # Instructs source to create a task file instead
                 configs.append(config)
 
             # Create the new models
-            models = create_models_ipyparallel(configs, ipp_client,
-                                               block=self.config.get('block_during_paralellization', False))
+            if ipp_client is not None:
+                models = create_models_ipyparallel(configs, ipp_client,
+                                                   block=self.config.get('block_during_paralellization', False))
+
+            else:
+                models = [Model(c) for c in configs]
+
+                hashes = set()
+                for m in models:
+                    for s in m.sources:
+                        hashes.add(s.hash)
+
+                compute_many(hashes, n_cores)
+
+                # Reload models so computation takes effect
+                models = [Model(c) for c in configs]
 
             # Add the new models to the anchor_models dict
             for zs, model in zip(zs_list, models):

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -15,7 +15,7 @@ from scipy.special import gammaln
 
 from .exceptions import NotPreparedException, InvalidParameterSpecification, InvalidParameter
 from .model import Model
-from .parallel import create_models_in_parallel
+from .parallel import create_models_ipyparallel
 from .pdf_morphers import MORPHERS
 from .utils import combine_dicts, inherit_docstring_from
 from . import inference
@@ -119,7 +119,7 @@ class LogLikelihoodBase(object):
                 configs.append(config)
 
             # Create the new models
-            models = create_models_in_parallel(configs, ipp_client,
+            models = create_models_ipyparallel(configs, ipp_client,
                                                block=self.config.get('block_during_paralellization', False))
 
             # Add the new models to the anchor_models dict

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -12,6 +12,7 @@ import numpy as np
 from multihist import Histdd
 from scipy import stats
 from scipy.special import gammaln
+from tqdm import tqdm
 
 from .exceptions import NotPreparedException, InvalidParameterSpecification, InvalidParameter
 from .model import Model
@@ -126,7 +127,7 @@ class LogLikelihoodBase(object):
                                                    block=self.config.get('block_during_paralellization', False))
 
             else:
-                models = [Model(c) for c in configs]
+                models = [Model(c) for c in tqdm(configs, desc="Preparing model computation tasks")]
 
                 hashes = set()
                 for m in models:
@@ -136,7 +137,7 @@ class LogLikelihoodBase(object):
                 compute_many(hashes, n_cores)
 
                 # Reload models so computation takes effect
-                models = [Model(c) for c in configs]
+                models = [Model(c) for c in tqdm(configs, desc="Loading computed models")]
 
             # Add the new models to the anchor_models dict
             for zs, model in zip(zs_list, models):

--- a/blueice/model.py
+++ b/blueice/model.py
@@ -111,11 +111,13 @@ class Model(object):
             return np.array([self.expected_events(s) for s in self.sources])
         return s.events_per_day * self.config['livetime_days'] * s.fraction_in_range * s.config['rate_multiplier']
 
-    def show(self, d, ax=None, dims=None):
+    def show(self, d, ax=None, dims=None, **kwargs):
         """Plot the events from dataset d in the analysis range
         ax: plot on this Axes
         Dims: numbers of dimension(s) to plot in. Can be up to two dimensions.
         """
+        kwargs.setdefault('s', 5)
+
         import matplotlib.pyplot as plt
         dim_names, bins = zip(*self.config['analysis_space'])
 
@@ -132,7 +134,7 @@ class Model(object):
             q_in_space = self.to_analysis_dimensions(q)
             ax.scatter(q_in_space[dims[0]],
                        q_in_space[dims[1]] if len(dims) > 1 else np.zeros(len(q)),
-                       color=s.config['color'], s=5, label=s.config['label'])
+                       color=s.config['color'], label=s.config['label'], **kwargs)
 
         ax.set_xlabel(dim_names[dims[0]])
         ax.set_xlim(bins[dims[0]][0], bins[dims[0]][-1])

--- a/blueice/model.py
+++ b/blueice/model.py
@@ -76,7 +76,7 @@ class Model(object):
             rate_multipliers = dict()
         ds = []
         for s_i, source in enumerate(self.sources):
-            mu = self.expected_events(source)
+            mu = self.expected_events(source) * rate_multipliers.get(source.name, 1)
             if livetime_days is not None:
                 # Adjust exposure to custom livetime-days
                 mu *= livetime_days / self.config['livetime_days']

--- a/blueice/model.py
+++ b/blueice/model.py
@@ -76,11 +76,15 @@ class Model(object):
             rate_multipliers = dict()
         ds = []
         for s_i, source in enumerate(self.sources):
-            mu = source.events_per_day * rate_multipliers.get(source.name, 1)
-            mu *= livetime_days if livetime_days is not None else self.config['livetime_days']
+            mu = self.expected_events(source)
+            if livetime_days is not None:
+                # Adjust exposure to custom livetime-days
+                mu *= livetime_days / self.config['livetime_days']
+
             d = source.simulate(np.random.poisson(mu))
             d['source'] = s_i
             ds.append(d)
+
         d = np.concatenate(ds)
         if restrict:
             d = self.range_cut(d)

--- a/blueice/parallel.py
+++ b/blueice/parallel.py
@@ -57,6 +57,7 @@ def compute_many(hashes, n_cpus=1, *args, **kwargs):
                 _done_is = []
                 for f_i, f in enumerate(futures):
                     if f.done():
+                        f.result()     # Raises exception on error
                         _done_is.append(f_i)
                         pbar.update(1)
                 futures = [f for f_i, f in enumerate(futures) if not f_i in _done_is]

--- a/blueice/parallel.py
+++ b/blueice/parallel.py
@@ -1,6 +1,6 @@
 """Parallel and delayed computation of models/sources for blueice.
 """
-
+import logging
 import os
 import time
 from concurrent.futures import ProcessPoolExecutor
@@ -11,6 +11,7 @@ from .utils import read_pickle
 from .model import Model
 
 __all__ = ['create_models_ipyparallel', 'compute_single', 'compute_many', 'compute_all']
+log = logging.getLogger('blueice.parallel')
 
 
 def compute_single(hash, task_dir='pdf_tasks', result_dir='pdf_cache'):
@@ -18,7 +19,7 @@ def compute_single(hash, task_dir='pdf_tasks', result_dir='pdf_cache'):
     # Do we have result with this hash?
     result_filename = os.path.join(result_dir, hash)
     if os.path.exists(result_filename):
-        print("Task %s already computed, nothing done." % hash)
+        log.debug("Task %s already computed, nothing done." % hash)
         return
 
     # Do we have a task with this hash?
@@ -38,11 +39,10 @@ def compute_single(hash, task_dir='pdf_tasks', result_dir='pdf_cache'):
     os.remove(task_filename)
 
     if s.hash != hash:
-        # TODO: Add debug message
+        # TODO: Fix this
         # Bad stuff, if this occurs you may want to look into hashablize...
         # Or maybe dill messes things up...
-        #print("Source hash somehow changed from %s to %s!" %(s.hash, hash))
-        #print("Renaming results file...")
+        log.debug("Source hash somehow changed from %s to %s!" %(s.hash, hash))
         os.rename(s._cache_filename, result_filename)
 
 

--- a/blueice/parallel.py
+++ b/blueice/parallel.py
@@ -1,10 +1,77 @@
+"""Parallel and delayed computation of models/sources for blueice.
+"""
+
+import os
+from concurrent.futures import ProcessPoolExecutor
+
 from tqdm import tqdm
+
+from .utils import read_pickle
 from .model import Model
 
-__all__ = ['create_models_in_parallel']
+__all__ = ['create_models_ipyparallel', 'compute_single', 'compute_many', 'compute_all']
 
 
-def create_models_in_parallel(configs, ipp_client=None, block=False):
+def compute_single(hash, task_dir='pdf_tasks', result_dir='pdf_cache'):
+    """Computes a single source PDF from a saved task file"""
+    # Do we have result with this hash?
+    result_filename = os.path.join(result_dir, hash)
+    if os.path.exists(result_filename):
+        print("Task %s already computed, nothing done." % hash)
+        return
+
+    # Do we have a task with this hash?
+    task_filename = os.path.join(task_dir, hash)
+    if not os.path.exists(task_filename):
+        # Abort, not going to compute something random.
+        raise ValueError("Hash %s does not correspond to a task or result" % hash)
+
+    source_class, source_config = read_pickle(task_filename)
+
+    # Compute the source pdf
+    source_config['pdf_cache_dir'] = result_dir
+    source_config['delay_pdf_computation'] = False
+    s = source_class(source_config)
+
+    # Remove the task file
+    os.remove(task_filename)
+
+    if s.hash != hash:
+        # Bad stuff, if this occurs you may want to look into hashablize...
+        # Or maybe dill messes things up...
+        print("Source hash somehow changed from %s to %s!" %(s.hash, hash))
+        print("Renaming results file...")
+        os.rename(s._cache_filename, result_filename)
+
+
+def compute_many(hashes, n_cpus=1, *args, **kwargs):
+    if n_cpus != 1:
+        pool = ProcessPoolExecutor(max_workers=n_cpus)
+        futures = []
+        for h in hashes:
+            futures.append(pool.submit(h, *args, **kwargs))
+
+        # Wait fot the futures to complete; give a progress bar
+        with tqdm(total=len(futures), desc='Computing on %d cores' % n_cpus) as pbar:
+            while len(futures):
+                _done_is = []
+                for f_i, f in enumerate(futures):
+                    if f.done():
+                        _done_is.append(f_i)
+                        pbar.update(1)
+                futures = [f for f_i, f in enumerate(futures) if not f_i in _done_is]
+    else:
+        for h in tqdm(hashes, desc='Computing on one core'):
+            compute_single(h, *args, **kwargs)
+
+
+def compute_all(input_dir='./pdf_cache', *args, **kwargs):
+    if not os.path.exists(input_dir):
+        raise FileNotFoundError("Input directory %s does not exist")
+    compute_many(os.listdir(input_dir), *args, **kwargs)
+
+
+def create_models_ipyparallel(configs, ipp_client=None, block=False):
     """Return Models for each configuration in configs.
     :param ipp_client: ipyparallel client to use for parallelized computation, or None (in which case models will be
                        computed serially. For now only engines running in the same directory as the main code
@@ -23,7 +90,7 @@ def create_models_in_parallel(configs, ipp_client=None, block=False):
         asyncresult = ipp_client.load_balanced_view().map(compute_model, configs, ordered=True, block=block)
         result = []
         for m in tqdm(asyncresult,
-                      desc="Computing models in parallel",
+                      desc="Computing models on %d cores" % len(ipp_client.ids),
                       smoothing=0,  # Show average speed, instantaneous speed is extremely variable
                       total=len(configs)):
             result.append(m)

--- a/blueice/parallel.py
+++ b/blueice/parallel.py
@@ -38,12 +38,10 @@ def compute_single(hash, task_dir='pdf_tasks', result_dir='pdf_cache'):
     # Remove the task file
     os.remove(task_filename)
 
+    assert os.path.exists(result_filename)
+
     if s.hash != hash:
-        # TODO: Fix this
-        # Bad stuff, if this occurs you may want to look into hashablize...
-        # Or maybe dill messes things up...
-        log.debug("Source hash somehow changed from %s to %s!" %(s.hash, hash))
-        os.rename(s._cache_filename, result_filename)
+        raise ValueError("source hash changed somehow??")
 
 
 def compute_many(hashes, n_cpus=1, *args, **kwargs):

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -46,6 +46,7 @@ class Source(object):
                         # some child classes set them dynamically (eg DensityEstimatingSource will set them based on
                         # the sample events you pass in).
                         events_per_day=0,         # Events per day this source produces (detected or not).
+                        rate_multiplier=1,        # Rate multiplier (independent of loglikelihood's rate multiplier)
                         fraction_in_range=1,      # Fraction of simulated events that fall in analysis space.
 
                         # List of attributes you want to be stored in cache. When the same config is passed later
@@ -70,7 +71,8 @@ class Source(object):
                         )
         c = utils.combine_dicts(defaults, config)
         c['cache_attributes'] += ['fraction_in_range', 'events_per_day', 'pdf_has_been_computed']
-        c['dont_hash_settings'] += ['force_recalculation', 'never_save_to_cache', 'dont_hash_settings',
+        c['dont_hash_settings'] += ['rate_multiplier',
+                                    'force_recalculation', 'never_save_to_cache', 'dont_hash_settings',
                                     'label', 'color', 'extra_dont_hash_settings', 'delay_pdf_computation',
                                     'cache_dir', 'task_dir']
 

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -91,7 +91,7 @@ class Source(object):
         self.fraction_in_range = c['fraction_in_range']
         self.pdf_has_been_computed = False
 
-        # What is this source's id?
+        # What is this source's unique id?
         if 'hash' in c:
             # id already given in config: probably because config has already been 'pimped' with loaded objects
             self.hash = c['hash']

--- a/blueice/test_helpers.py
+++ b/blueice/test_helpers.py
@@ -29,8 +29,11 @@ class GaussianSource(GaussianSourceBase):
     def compute_pdf(self):
         self.events_per_day *= self.config.get('some_multiplier', 1)
         self.events_per_day *= len(self.config.get('strlen_multiplier', 'x'))
+        super().compute_pdf()
 
     def pdf(self, *args):
+        if not self.pdf_has_been_computed:
+            raise RuntimeError("Trying to call a PDF that hasn't been computed!")
         return stats.norm(self.config['mu'], self.config['sigma']).pdf(args[0])
 
 

--- a/blueice/utils.py
+++ b/blueice/utils.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 import os
 import pickle
+import pickle as _builtin_pickle
+import dill as pickle
 from hashlib import sha1
 
 import numpy as np
@@ -92,7 +94,7 @@ def hashablize(obj):
 
 def deterministic_hash(thing):
     """Return a deterministic hash of a container hierarchy using hashablize, pickle and sha1"""
-    return sha1(pickle.dumps(hashablize(thing))).hexdigest()
+    return sha1(_builtin_pickle.dumps(hashablize(thing))).hexdigest()
 
 
 def _events_to_analysis_dimensions(events, analysis_space):

--- a/blueice/utils.py
+++ b/blueice/utils.py
@@ -69,6 +69,9 @@ def read_pickle(filename):
 
 def save_pickle(stuff, filename):
     """Saves stuff in a pickle at filename"""
+    dirname = os.path.dirname(filename)
+    if dirname != '' and not os.path.exists(dirname):
+        os.makedirs(dirname)
     with open(filename, mode='wb') as outfile:
         pickle.dump(stuff, outfile)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ wheel>=0.23.0
 numpy>=1.9.0
 # matplotlib>=1.3.0
 pandas
+dill
 scipy>=0.15
 tqdm                 # Progress bar library
 multihist>=0.4.3     # Histogram library


### PR DESCRIPTION
This adds:
* An `n_cores` option to the `prepare` method of likelihood functions, to allow parallel model computation on several machines. 
* Experimental (as in, I have no idea if it works yet): A source can now make a file in `pdf_tasks` which contains all information needed to compute the pdf. The `bluethaw` script can turn this into a pdf_cache file. Using this you can compute models remotely / on a batch queue.
* Adds `bestfit_emcee`, to fit likelihoods using emcee (and optionally get pre-made corner plots etc).

The old ipyparallel paralellization interface is preserved for compatibility.
 