### PR TITLE
Cache loaded source data to reduce memory footprint

### DIFF
--- a/blueice/inference.py
+++ b/blueice/inference.py
@@ -29,8 +29,31 @@ except ImportError:
                   "conda install -c astropy iminuit")
     DEFAULT_BESTFIT_ROUTINE = 'scipy'
 
-__all__ = ['make_objective', 'bestfit_scipy', 'bestfit_minuit', 'plot_likelihood_ratio', 'one_parameter_interval',
-           'bestfit_emcee']
+__all__ = ['best_anchor', 'make_objective', 'bestfit_scipy', 'bestfit_minuit', 'plot_likelihood_ratio',
+           'one_parameter_interval', 'bestfit_emcee']
+
+
+def best_anchor(lf):
+    """Return shape parameter dictionary of anchor model with highest likelihood.
+    Useful as a guess for further fitting.
+    """
+    if not len(lf.shape_parameters):
+        return dict()
+
+    shape_par_names = list(lf.shape_parameters.keys())
+    anchors = list(lf.anchor_models.keys())
+    results = np.zeros(len(anchors))
+
+    def dictzip_shapes(anchor_vals):
+        return {shape_par_names[j]: anchor_vals[j]
+                for j in range(len(shape_par_names))}
+
+    for i, anchor_vals in enumerate(anchors):
+        results[i] = lf(**dictzip_shapes(anchor_vals))
+
+    best_i = np.argmax(results)
+
+    return dictzip_shapes(anchors[best_i])
 
 
 def make_objective(lf, guess=None, minus=True, rates_in_log_space=False, **kwargs):
@@ -229,7 +252,7 @@ def bestfit_emcee(ll, quiet=False, return_errors=False, return_samples=False,
     :param ll: LogLikelihood to optimize
     :param quiet: if False (default), show corner plot and print out passthrough info
     :param return_errors: if True, return a third result, dictionary with 1 sigma errors for each parameter
-    :param return_errors: if True, return a third result, flattened numpy array of samples visited (except in burn-in)
+    :param return_samples: if True, return a third result, flattened numpy array of samples visited (except in burn-in)
     :param n_walkers: Number of walkers to use for the MCMC
     :param n_steps: Number of steps to use for MCMC
     :param n_burn_in: Number of burn-in steps to use. These are added to n_steps but thrown away.

--- a/blueice/inference.py
+++ b/blueice/inference.py
@@ -235,7 +235,7 @@ def bestfit_emcee(ll, quiet=False, return_errors=False, return_samples=False,
     :param n_burn_in: Number of burn-in steps to use. These are added to n_steps but thrown away.
     :param n_threads: Number of concurrent threads to use
     :param kwargs: Passed to ll.make_objective.
-    :return:
+    :return: {param: best fit}, maximum loglikelihood.
     """
     import emcee
 
@@ -360,7 +360,7 @@ def one_parameter_interval(lf, target, bound,
 def plot_likelihood_ratio(lf, *space, vmax=15,
                           bestfit_routine=None,
                           plot_kwargs=None, **kwargs):
-    """Plots the loglikelihood ratio derived from LogLikelihood lf in a parameter space
+    """Plots the - loglikelihood ratio derived from LogLikelihood lf in a parameter space
     :param lf: LogLikelihood function with data set.
     :param space: list/tuple of tuples (dimname, points to plot)
     :param vmax: Limit for color bar (2d) or y axis (1d)
@@ -374,7 +374,7 @@ def plot_likelihood_ratio(lf, *space, vmax=15,
         plot_kwargs = {}
 
     results = []
-    label = "Log likelihood ratio"
+    label = "-Log likelihood ratio"
     if len(space) == 1:
         dim, x = space[0]
         for q in x:


### PR DESCRIPTION
This lets Source keep a dictionary cache of loaded source-data (like PDFs), which reduces memory footprint if the same source is being loaded many times (for example, in models with many nuisance parameters that don't affect all sources). Thanks to @kdund for spotting and correctly diagnosing the problem.

I also included two bonus features I've been meaning to commit for a while:
  * Skip pdf_task file creation if you're doing single-core computation. You can just as well compute the PDF immediately.
  * `best_anchor` inference method, which finds the shape parameter anchor combination that best matches the data. Useful as a guess for further fitting.