### PR TITLE
Add compute_pdf to LogLikelihoodSum.__call__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ install:
   - ulimit -a -H
   - cat /proc/sys/kernel/core_pattern
   # Download numpy etc. binaries from binstar
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy pandas
+  - conda create -n travis_env --yes python=$TRAVIS_PYTHON_VERSION numpy scipy pandas
+  - source activate travis_env
   - conda install -c astropy iminuit
   # Setup coverage for converage measurement
   - pip install coverage

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -600,12 +600,12 @@ class LogLikelihoodSum(object):
                     self.pdf_base_config[shape_parameter_name] = base_value
             self.likelihood_parameters.append(parameter_names)
     
-    def __call__(self,livetime_days=None, **kwargs):
+    def __call__(self, compute_pdf=False, livetime_days=None, **kwargs):
         ret = 0.
         for ll,parameter_names in zip(self.likelihood_list, self.likelihood_parameters):
             pass_kwargs = {k: v for k, v in kwargs.items() if k in parameter_names}
  
-            ret += ll(livetime_days=livetime_days, **pass_kwargs)
+            ret += ll(compute_pdf=compute_pdf, livetime_days=livetime_days, **pass_kwargs)
         return ret
 
     def get_bounds(self, parameter_name=None):


### PR DESCRIPTION
I propose to add compute_pdf to the LogLikelihoodSum call. This way pdfs can be recomputed for each of the likelihoods in a likelihood sum (needed in case of analytical pdfs). This also makes it behave the same way as the LogLikelihoodBase call.