### PR TITLE
Simplify travis, scipy instead of iminuit as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
   - pip install coveralls
   - python setup.py install
 script:
-  - coverage run --source=strax setup.py test
+  - coverage run --source=blueice setup.py test
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,72 +1,12 @@
 language: python
 python:
-  - 3.4
-notifications:
-  email: false
-
-sudo: false
-
-addons:
-  apt:
-    packages:
-     - gdb
-     - apport
-
-before_install:
-  # What is the current file size max for core files?
-  # It is usually 0, which means no core file will be dumped if there is a crash
-  - ulimit -c
-  - ulimit -a -S
-  - ulimit -a -H
-  # Setup Miniconda - a lightweight anaconda
-  # This allows us to get pre-build binaries from numpy etc. from binstar
-  # This is quicker and more reliable than compiling from source every build
-  # See  https://gist.githubusercontent.com/dan-blanchard/7045057/raw/8ca5a4abcd0c65ab05217dd92119001f8454c369/.travis.yml
-  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update --yes conda
-
+  - "3.4"
+  - "3.6"
 install:
-  # Set the core file limit to unlimited so a core file is generated upon crash
-  - ulimit -c unlimited -S
-  - ulimit -c
-  - ulimit -a -S
-  - ulimit -a -H
-  - cat /proc/sys/kernel/core_pattern
-  # Download numpy etc. binaries from binstar
-  - conda create -n travis_env --yes python=$TRAVIS_PYTHON_VERSION numpy scipy pandas
-  - source activate travis_env
-  - conda install -c astropy iminuit
-  # Setup coverage for converage measurement
-  - pip install coverage
+  - pip install -r requirements.txt
   - pip install coveralls
   - python setup.py install
-
-
-before_script:
-  - RESULT=0
-
-
 script:
-  # Run the program to prompt a crash
-  # Note: we capture the return code of the program here and add
-  # `|| true` to ensure that travis continues past the crash
-  # Run tests
-  - coverage run --source=blueice setup.py test || RESULT=$?
-  - ls -l
-  - if [[ ${RESULT} == 0 ]]; then echo "\\o/ our test worked without problems"; else echo "ruhroh test returned an errorcode of $RESULT"; fi;
-  # If the program returned an error code, now we check for a
-  # core file in the current working directory and dump the backtrace out
-  - for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb python core* -ex "thread apply all bt" -ex "set pagination 0" -batch; done;
-  # now we should present travis with the original
-  # error code so the run cleanly stops
-  - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;
-
-
+  - coverage run --source=strax setup.py test
 after_success:
-  # Calculate coverage
-  - coveralls
+- coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
+  - pip install iminuit
   - pip install coveralls
   - python setup.py install
 script:

--- a/blueice/inference.py
+++ b/blueice/inference.py
@@ -22,12 +22,10 @@ try:
     # Import imunuit here, so blueice works also for people who don't have it installed.
     from iminuit.util import make_func_code     # noqa
     from iminuit import Minuit                  # noqa
-    DEFAULT_BESTFIT_ROUTINE = 'minuit'
 except ImportError:
-    warnings.warn("You don't have iminuit installed; switching to scipy minimizers."
-                  "We've had several issues with these on degenerate problems, you're advised to do "
-                  "conda install -c astropy iminuit")
-    DEFAULT_BESTFIT_ROUTINE = 'scipy'
+    pass
+
+DEFAULT_BESTFIT_ROUTINE = 'scipy'
 
 __all__ = ['best_anchor', 'make_objective', 'bestfit_scipy', 'bestfit_minuit', 'plot_likelihood_ratio',
            'one_parameter_interval', 'bestfit_emcee']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ scipy>=0.15
 tqdm                 # Progress bar library
 multihist>=0.4.3     # Histogram library
 pytest>=3.0.0        # 3.0 needed for a yield statement in a fixture
-# Not required, but recommended:
-#  iminuit              # The Minuit minimizer


### PR DESCRIPTION
This wil:
  * Set scipy minimizers to be the default, even if you have iminuit installed. In my code and what I've seen from @kdund we use scipy minimizers exclusively; apparently the problems we once had with these are now resolved and/or we had other problems with iminuit. Or maybe it's just setting the Powell method that did the magic? In any case, if nobody is using iminuit it probably shouldn't be the default. @pelssers, since you implemented the iminuit minimizers, would you agree?
  * Simplify the travis build instructions. Since wheels exist we do not need anaconda to install binaries, so the travis file can just be a few lines.
  * Also test python 3.6 on Travis.

