### PR TITLE
Add likelihood that takes coupling as shape parameters

### DIFF
--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -862,5 +862,5 @@ class LogAncillaryLikelihood(object):
 
 # Add the inference methods from .inference
 for methodname in inference.__all__:
-    for q in (LogLikelihoodBase, LogLikelihoodSum, LogAncillaryLikelihood, LogLikelihoodVaried):
+    for q in (LogLikelihoodBase, LogLikelihoodSum, LogAncillaryLikelihood, LogLikelihoodReParam):
         setattr(q, methodname, getattr(inference, methodname))

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -21,7 +21,7 @@ from .utils import combine_dicts, inherit_docstring_from
 from . import inference
 
 __all__ = ['LogLikelihoodBase', 'BinnedLogLikelihood', 'UnbinnedLogLikelihood', 'LogLikelihoodSum',
-           'LogLikelihoodVaried']
+           'LogLikelihoodReParam']
 
 
 ##
@@ -581,7 +581,7 @@ def beeston_barlow_roots(a, p, U, d):
     return beeston_barlow_root1(a, p, U, d), beeston_barlow_root2(a, p, U, d)
 
 
-class LogLikelihoodVaried(object):
+class LogLikelihoodReParam(object):
     """Class that enables source dependent on several couplings."""
 
     def __init__(self, likelihood, conv_config):

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -612,7 +612,8 @@ class LogLikelihoodReParam(object):
                     if p not in new_params_2:
                         new_params_2.append(p)
 
-        assert new_params_1 == new_params_2, "New parameters are not consistent, double check conv_config..."
+        # order doesn't matter
+        assert set(new_params_1) == set(new_params_2), "New parameters are not consistent, double check conv_config..."
 
         # also check if new params are in config or not
         missing_params = ""

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -653,27 +653,6 @@ class LogLikelihoodReParam(object):
         model.simulate = self._simulate
         return model
 
-    # @property
-    # def pdf_base_config(self):
-    #     """wrapper for the pdf_base_config. Mostly adjust the rate multipliers of signals based on the couplings"""
-    #     pdf_base_config = deepcopy(self.__likelihood.pdf_base_config)
-    #     rate_dict = dict()
-    #     for k, v in self.conv_config.items():
-    #         if k.endswith("_rate_multiplier"):
-    #             params = [pdf_base_config.get(p) for p in v["params"]]
-    #             source_name = k.split("_rate_multiplier")[0]
-    #             rate_dict[source_name] = v["func"](*params)
-    #
-    #     # update config
-    #     sources_copy = deepcopy(pdf_base_config["sources"])
-    #     for s in sources_copy:
-    #         source_name = s["name"]
-    #         if source_name in rate_dict.keys():
-    #             s["rate"] *= rate_dict[source_name]
-    #
-    #     pdf_base_config["sources"] = sources_copy
-    #     return pdf_base_config
-
     def set_data(self, df):
         self.__likelihood.set_data(df)
 

--- a/blueice/test_helpers.py
+++ b/blueice/test_helpers.py
@@ -66,6 +66,16 @@ BASE_CONFIG = dict(
 )
 
 
+# base config for conv_config
+BASE_CONV_CONFIG = dict(
+    np0=(np.linspace(1e-12, 10, 2), None, None),
+    np1=(np.linspace(1e-12, 10, 2), None, None),
+    op0_rate_multiplier=dict(params=["np0"], func=lambda np0: np0**2),
+    op1_rate_multiplier=dict(params=["np1"], func=lambda np1: np1**2),
+    op2_rate_multiplier=dict(params=["np0", "np1"], func=lambda np0, np1: np0*np1),
+)
+
+
 def test_conf(n_sources=1, mc=False, **kwargs):
     conf = deepcopy(BASE_CONFIG)
     conf['sources'] = [{'name': 's%d' % i} for i in range(n_sources)]
@@ -73,6 +83,18 @@ def test_conf(n_sources=1, mc=False, **kwargs):
         conf['default_source_class'] = GaussianMCSource
     return combine_dicts(conf, kwargs)
 
+def test_conf_reparam(n_source=1, mc=False, **kwargs):
+    conf = test_conf(n_source, mc, **kwargs)
+    # config for reparam
+    conf["sources"] = [
+        dict(name="op0"),
+        dict(name="op1"),
+        dict(name="op2"),
+    ]
+
+    conf["np0"] = 1
+    conf["np1"] = 1
+    return conf
 
 def almost_equal(a, b, fraction=1e-6):
     return abs((a - b)/a) <= fraction

--- a/tests/test_likelihood_reparam.py
+++ b/tests/test_likelihood_reparam.py
@@ -97,8 +97,3 @@ def test_consistency_new_params(use_wrong_config=False, use_wrong_conv_config=Fa
 
     # get new likelihood
     lf_reparam = LogLikelihoodReParam(lf_old, conv_config)
-
-
-
-
-

--- a/tests/test_likelihood_reparam.py
+++ b/tests/test_likelihood_reparam.py
@@ -1,0 +1,104 @@
+from blueice.test_helpers import *
+from blueice.likelihood import UnbinnedLogLikelihood, LogLikelihoodReParam
+import numpy as np
+from scipy import stats
+from copy import deepcopy
+
+
+def test_likelihood_value():
+    """Just a sanity check to show we get the right likelihood values"""
+    config = test_conf_reparam(events_per_day=1)
+    conv_config = deepcopy(BASE_CONV_CONFIG)
+    # initialize the old likelihood first
+    # this is an input for the reparameterized likelihood
+    lf_old = UnbinnedLogLikelihood(config)
+
+    lf_old.add_rate_parameter("op0")
+    lf_old.add_rate_parameter("op1")
+    lf_old.add_rate_parameter("op2")
+
+    lf_old.prepare()
+
+    # get new likelihood
+    lf_reparam = LogLikelihoodReParam(lf_old, conv_config)
+
+    # dummy data
+    d = np.zeros(3, dtype=[('x', np.float), ('source', np.int)])
+    lf_reparam.set_data(d)
+
+    def compute_lf(np0=1, np1=1):
+        """likelihood under the dummy data"""
+        op0 = np0 ** 2
+        op1 = np1 ** 2
+        op2 = np0 * np1
+        sum_s = op0 + op1 + op2
+        return -sum_s + 3 * np.log(sum_s) + 3 * stats.norm.logpdf(0)
+
+    # check if the likelihood is computed correctly
+    np0_s, np1_s = [1, 2, 3], [1, 2, 3]
+    for np0, np1 in zip(np0_s, np1_s):
+        assert np.isclose(lf_reparam(np0=np0, np1=np1), compute_lf(np0=np0, np1=np1), atol=1e-08)
+
+
+def test_likelihoods_before_after_reparam():
+    """Compare the likelihood before and after reparameterization"""
+    config = test_conf_reparam(events_per_day=1)
+    conv_config = deepcopy(BASE_CONV_CONFIG)
+    # initialize the old likelihood first
+    # this is an input for the reparameterized likelihood
+    lf_old = UnbinnedLogLikelihood(config)
+
+    lf_old.add_rate_parameter("op0")
+    lf_old.add_rate_parameter("op1")
+    lf_old.add_rate_parameter("op2")
+
+    lf_old.prepare()
+
+    # get new likelihood
+    lf_reparam = LogLikelihoodReParam(lf_old, conv_config)
+
+    # set data
+    d = lf_reparam.base_model.simulate()
+    lf_reparam.set_data(d)
+    lf_old.set_data(d)
+
+    # check
+    assert np.isclose(lf_reparam(), lf_old())
+    assert np.isclose(lf_reparam(np0=2), lf_old(op0_rate_multiplier=4, op2_rate_multiplier=2))
+    assert np.isclose(lf_reparam(np1=2), lf_old(op1_rate_multiplier=4, op2_rate_multiplier=2))
+    assert np.isclose(lf_reparam(np0=2, np1=2),
+                      lf_old(op0_rate_multiplier=4, op1_rate_multiplier=4, op2_rate_multiplier=4))
+
+
+def test_consistency_new_params(use_wrong_config=False, use_wrong_conv_config=False):
+    """Check if the input new parameters are consistent:
+    1) inside the conv_config
+    2) between conv_config and config
+    """
+    config = test_conf_reparam(events_per_day=1)
+    conv_config = deepcopy(BASE_CONV_CONFIG)
+
+    if use_wrong_config:
+        config.pop("np0")
+        config.pop("np1")
+
+    if use_wrong_conv_config:
+        conv_config["np2"] = (np.linspace(1e-12, 10, 2), None, None)
+
+    # initialize the old likelihood first
+    # this is an input for the reparameterized likelihood
+    lf_old = UnbinnedLogLikelihood(config)
+
+    lf_old.add_rate_parameter("op0")
+    lf_old.add_rate_parameter("op1")
+    lf_old.add_rate_parameter("op2")
+
+    lf_old.prepare()
+
+    # get new likelihood
+    lf_reparam = LogLikelihoodReParam(lf_old, conv_config)
+
+
+
+
+


### PR DESCRIPTION
In some cases, we have a bunch of signals that depend on shared couplings. For instance, if we have:
  * signal_a <img src="https://render.githubusercontent.com/render/math?math=\propto g_1 + g_2">
  * signal_b <img src="https://render.githubusercontent.com/render/math?math=\propto g_1^2 g_2">
  * signal_c <img src="https://render.githubusercontent.com/render/math?math=\propto g_1 g_2^2">

Instead of the rate multipliers of signal a, b, and c, we want to set constraints on the coupling `g1` and `g2` directly, because in this way:
* we only need to work on fewer parameters
* the rate correlation between different signals is properly accounted for

This PR addresses exactly the issue by adding the coupling parameters into the shape parameters. A conversion config `conv_config` is passed to initialize a new likelihood called `UnbinnedLogLikelihoodVaried` so that the likelihood knows how to translate the couplings to rate multipliers for each signal source later. The prior constraint on the coupling parameter itself is also possible.

In fact, the new likelihood can handle more than the coupling -- should any shape parameter has a correlation with the signal rate, it can be realized by writing this correlation info in the conversion config.