### PR TITLE
Patch for tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,8 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest wheel
         pip install -r requirements.txt
+        # Not technically required, but causes extra tests to run
+        pip install iminuit
     - name: Install package
       run: |
         pip install .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,25 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  test_blueice:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest wheel
+        pip install -r requirements.txt
+    - name: Install package
+      run: |
+        pip install .
+    - name: Test with pytest
+      run: |
+        pytest

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 blueice: Build Likelihoods Using Efficient Interpolations and monte-Carlo generated Events
 ==========================================================================================
-.. image:: https://travis-ci.org/JelleAalbers/blueice.svg?branch=master
-    :target: https://travis-ci.org/JelleAalbers/blueice
+.. image:: https://github.com/JelleAalbers/blueice/actions/workflows/pytest.yml/badge.svg?branch=master
+    :target: https://github.com/JelleAalbers/blueice/actions/workflows/pytest.yml
 .. image:: https://coveralls.io/repos/github/JelleAalbers/blueice/badge.svg?branch=master
     :target: https://coveralls.io/github/JelleAalbers/blueice?branch=master
 .. image:: https://readthedocs.org/projects/blueice/badge/?version=latest

--- a/blueice/data_reading.py
+++ b/blueice/data_reading.py
@@ -14,7 +14,7 @@ __all__ = ['read_csv', 'read_files_in']
 
 def read_csv(filename):
     result = pd.read_csv(filename, delimiter=',', names=['x', 'y'], comment='#')
-    result = result.values[1:].astype(np.float).T
+    result = result.values[1:].astype(float).T
     return result
 
 

--- a/blueice/model.py
+++ b/blueice/model.py
@@ -61,7 +61,7 @@ class Model(object):
 
     def range_cut(self, d):
         """Return events from dataset d which are inside the bounds of the analysis space"""
-        mask = np.ones(len(d), dtype=np.bool)
+        mask = np.ones(len(d), dtype=bool)
         for dimension, bin_edges in self.config['analysis_space']:
             mask = mask & (d[dimension] >= bin_edges[0]) & (d[dimension] <= bin_edges[-1])
         return d[mask]

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -250,8 +250,8 @@ class HistogramPdfSource(Source):
 
         # Convert to numpy record array
         d = np.zeros(n_events,
-                     dtype=[('source', np.int)] +
-                           [(x[0], np.float)
+                     dtype=[('source', int)] +
+                           [(x[0], float)
                             for x in self.config['analysis_space']])
         for i, x in enumerate(self.config['analysis_space']):
             d[x[0]] = q[:, i]
@@ -300,7 +300,7 @@ class DensityEstimatingSource(HistogramPdfSource):
         #    (fraction_in_range keeps track of how many events were not in range)
         #  - the bin sizes
         self._pdf_histogram = mh.similar_blank_hist()
-        self._pdf_histogram.histogram = mh.histogram.astype(np.float) / mh.n
+        self._pdf_histogram.histogram = mh.histogram.astype(float) / mh.n
 
         # For the bin widths we need to take an outer product of several vectors, for which numpy has no builtin
         # This reduce trick does the job instead, see http://stackoverflow.com/questions/17138393

--- a/blueice/test_helpers.py
+++ b/blueice/test_helpers.py
@@ -76,15 +76,15 @@ BASE_CONV_CONFIG = dict(
 )
 
 
-def test_conf(n_sources=1, mc=False, **kwargs):
+def conf_for_test(n_sources=1, mc=False, **kwargs):
     conf = deepcopy(BASE_CONFIG)
     conf['sources'] = [{'name': 's%d' % i} for i in range(n_sources)]
     if mc:
         conf['default_source_class'] = GaussianMCSource
     return combine_dicts(conf, kwargs)
 
-def test_conf_reparam(n_source=1, mc=False, **kwargs):
-    conf = test_conf(n_source, mc, **kwargs)
+def conf_for_reparam_test(n_source=1, mc=False, **kwargs):
+    conf = conf_for_test(n_source, mc, **kwargs)
     # config for reparam
     conf["sources"] = [
         dict(name="op0"),

--- a/blueice/test_helpers.py
+++ b/blueice/test_helpers.py
@@ -14,7 +14,7 @@ class GaussianSourceBase(Source):
     """Analog of GaussianSource which generates its events by PDF
     """
     def simulate(self, n_events):
-        d = np.zeros(n_events, dtype=[('x', np.float), ('source', np.int)])
+        d = np.zeros(n_events, dtype=[('x', float), ('source', int)])
         d['x'] = stats.norm(self.config['mu'], self.config['sigma']).rvs(n_events)
         return d
 
@@ -109,9 +109,9 @@ def make_data(instructions):
     """
     n_tot = sum([x['n_events'] for x in instructions])
 
-    d = np.zeros(n_tot, dtype=[('source', np.int),
-                               ('x', np.float),
-                               ('y', np.float)])
+    d = np.zeros(n_tot, dtype=[('source', int),
+                               ('x', float),
+                               ('y', float)])
 
     n_done = 0
     for instr in instructions:

--- a/tests/test_BeestonBarlow.py
+++ b/tests/test_BeestonBarlow.py
@@ -26,7 +26,7 @@ def test_BeestonBarlowSingleBin():
     assert lf.n_model_events is not None
 
     # Make a single event at x=0
-    lf.set_data(np.zeros(2, dtype=[('x', np.float), ('source', np.int)]))
+    lf.set_data(np.zeros(2, dtype=[('x', float), ('source', int)]))
 
     assert lf.n_model_events is not None
     assert almost_equal(28.0814209, beeston_barlow_root2(np.array([32]), 0.2, np.array([1]), np.array([2])))
@@ -55,7 +55,7 @@ def test_BeestonBarlowMultiBin():
     lf.prepare()
     assert lf.n_model_events is not None
 
-    # Make events: 
+    # Make events:
     instructions_mc = [dict(n_events=3, x=0.5),
                        dict(n_events=5, x=1.5),
                        dict(n_events=2, x=2.5),
@@ -107,7 +107,7 @@ def test_BeestonBarlow_second_source():
     lf.prepare()
     assert lf.n_model_events is not None
 
-    # Make events: 
+    # Make events:
     instructions_mc = [dict(n_events=3, x=0.5),
                        dict(n_events=5, x=1.5),
                        dict(n_events=2, x=2.5),

--- a/tests/test_BeestonBarlow.py
+++ b/tests/test_BeestonBarlow.py
@@ -14,7 +14,7 @@ def test_BeestonBarlowSingleBin():
     instructions_mc = [dict(n_events=32, x=0.5)]
     data, n_mc = make_data(instructions_mc)
 
-    conf = test_conf(default_source_class=FixedSampleSource,
+    conf = conf_for_test(default_source_class=FixedSampleSource,
                      events_per_day=32/5,
                      analysis_space=[['x', [0, 1]]],
                      data=data)
@@ -44,7 +44,7 @@ def test_BeestonBarlowMultiBin():
                        dict(n_events=27, x=3.5),]
     data, n_mc = make_data(instructions_mc)
 
-    conf = test_conf(default_source_class=FixedSampleSource,
+    conf = conf_for_test(default_source_class=FixedSampleSource,
                      events_per_day=105/5,
                      analysis_space=[['x', [0, 1, 2, 3, 4]]],
                      data=data)
@@ -92,7 +92,7 @@ def test_BeestonBarlow_second_source():
 
     # in sum, 105 calibration/mc evts.
 
-    conf = test_conf(default_source_class=FixedSampleSource,
+    conf = conf_for_test(default_source_class=FixedSampleSource,
                      analysis_space=[['x', [0, 1, 2, 3, 4]]],
                      dummy=1)
 

--- a/tests/test_binned_likelihood.py
+++ b/tests/test_binned_likelihood.py
@@ -16,7 +16,7 @@ def test_single_bin():
 
     # Make a single event at x=0
     lf.set_data(np.zeros(1,
-                         dtype=[('x', np.float), ('source', np.int)]))
+                         dtype=[('x', float), ('source', int)]))
 
     assert lf() == stats.poisson(1000).logpmf(1)
     assert lf(s0_rate_multiplier=5.4) == stats.poisson(5400).logpmf(1)
@@ -31,7 +31,7 @@ def test_twobin_mc():
 
     # Make 100 events at x=1
     lf.set_data(np.ones(100,
-                        dtype=[('x', np.float), ('source', np.int)]))
+                        dtype=[('x', float), ('source', int)]))
 
     assert almost_equal(lf(),
                         stats.poisson(500).logpmf(100) + stats.poisson(500).logpmf(0),
@@ -77,7 +77,7 @@ def test_multi_bin():
 
     lf = BinnedLogLikelihood(conf)
     lf.add_rate_parameter('s0')
-    
+
     lf.add_shape_parameter('strlen_multiplier', {1: 'x', 2: 'hi', 3:'wha'},base_value=1)
     lf.prepare()
 

--- a/tests/test_binned_likelihood.py
+++ b/tests/test_binned_likelihood.py
@@ -8,7 +8,7 @@ import pytest
 
 
 def test_single_bin():
-    conf = test_conf(mc=True, analysis_space=[['x', [-40,40 ]]])
+    conf = conf_for_test(mc=True, analysis_space=[['x', [-40,40 ]]])
 
     lf = BinnedLogLikelihood(conf)
     lf.add_rate_parameter('s0')
@@ -23,7 +23,7 @@ def test_single_bin():
 
 
 def test_twobin_mc():
-    conf = test_conf(mc=True, analysis_space=[['x', [-40, 0, 40]]])
+    conf = conf_for_test(mc=True, analysis_space=[['x', [-40, 0, 40]]])
 
     lf = BinnedLogLikelihood(conf)
     lf.add_rate_parameter('s0')
@@ -43,7 +43,7 @@ def test_multi_bin_single_dim():
                        dict(n_events=56, x=1.5)]
     data, n_mc = make_data(instructions_mc)
 
-    conf = test_conf(events_per_day=42,
+    conf = conf_for_test(events_per_day=42,
                      analysis_space=[['x', [0, 1, 5]]], default_source_class=FixedSampleSource, data=data)
 
     lf = BinnedLogLikelihood(conf)
@@ -72,7 +72,7 @@ def test_multi_bin():
                        dict(n_events=14, x=1.5, y=2)]
     data, n_mc = make_data(instructions_mc)
 
-    conf = test_conf(events_per_day=42, default_source_class=FixedSampleSource, data=data,
+    conf = conf_for_test(events_per_day=42, default_source_class=FixedSampleSource, data=data,
                      analysis_space=[['x', [0, 1, 5]], ['y', [0, 1, 4]]])
 
     lf = BinnedLogLikelihood(conf)

--- a/tests/test_data_reading.py
+++ b/tests/test_data_reading.py
@@ -47,5 +47,5 @@ def test_data_reading(tempdir):
     assert full_path in data_reading.CACHE
 
     # Test if we can read the test config without crashing
-    data_reading.read_files_in(test_conf(), data_dirs=tempdir)
+    data_reading.read_files_in(conf_for_test(), data_dirs=tempdir)
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,5 +1,4 @@
-# import matplotlib
-# matplotlib.use('agg')
+import pytest
 
 from blueice.test_helpers import *
 from blueice.inference import *
@@ -7,6 +6,10 @@ from blueice.likelihood import UnbinnedLogLikelihood as LogLikelihood
 
 
 def test_fit_minuit():
+    import iminuit
+    if not iminuit.__version__.startswith('1.'):
+        pytest.skip("Blueice's minuit wrappers assume minuit 1.x")
+
     # Single rate parameter
     lf = LogLikelihood(test_conf())
     lf.add_rate_parameter('s0')

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -14,7 +14,7 @@ def test_fit_minuit():
         pytest.skip("Blueice's minuit wrappers assume iminuit 1.x")
 
     # Single rate parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_rate_parameter('s0')
     lf.set_data(lf.base_model.simulate())
     fit_result, ll = bestfit_minuit(lf)
@@ -27,7 +27,7 @@ def test_fit_minuit():
     assert ll == lf(s0_rate_multiplier=1)
 
     # Single shape parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_shape_parameter('some_multiplier', (0.5, 1, 1.5, 2))
     lf.prepare()
     lf.set_data(lf.base_model.simulate())
@@ -35,7 +35,7 @@ def test_fit_minuit():
     assert 'some_multiplier' in fit_result
 
     # Shape and rate parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_rate_parameter('s0')
     lf.add_shape_parameter('some_multiplier', (0.5, 1, 1.5, 2))
     lf.prepare()
@@ -45,7 +45,7 @@ def test_fit_minuit():
     assert 's0_rate_multiplier' in fit_result
 
     # Non-numeric shape parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_shape_parameter('strlen_multiplier', {1: 'x', 2: 'hi', 3:'wha'}, base_value=1)
     lf.prepare()
     lf.set_data(lf.base_model.simulate())
@@ -54,7 +54,7 @@ def test_fit_minuit():
 
 def test_fit_scipy():
     # Single rate parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_rate_parameter('s0')
     lf.set_data(lf.base_model.simulate())
     fit_result, ll = bestfit_scipy(lf)
@@ -67,7 +67,7 @@ def test_fit_scipy():
     assert ll == lf(s0_rate_multiplier=1)
 
     # Single shape parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_shape_parameter('some_multiplier', (0.5, 1, 1.5, 2))
     lf.prepare()
     lf.set_data(lf.base_model.simulate())
@@ -75,7 +75,7 @@ def test_fit_scipy():
     assert 'some_multiplier' in fit_result
 
     # Shape and rate parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_rate_parameter('s0')
     lf.add_shape_parameter('some_multiplier', (0.5, 1, 1.5, 2))
     lf.prepare()
@@ -85,7 +85,7 @@ def test_fit_scipy():
     assert 's0_rate_multiplier' in fit_result
 
     # Non-numeric shape parameter
-    lf = LogLikelihood(test_conf())
+    lf = LogLikelihood(conf_for_test())
     lf.add_shape_parameter('strlen_multiplier', {1: 'x', 2: 'hi', 3:'wha'}, base_value=1)
     lf.prepare()
     lf.set_data(lf.base_model.simulate())
@@ -116,7 +116,7 @@ def test_limit():
     """Test the limit setting code
     For now just tests if it runs, does not test whether the results are correct...
     """
-    lf = LogLikelihood(test_conf(n_sources=2))
+    lf = LogLikelihood(conf_for_test(n_sources=2))
     lf.add_rate_parameter('s0')
     lf.prepare()
     lf.set_data(lf.base_model.simulate())

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -6,9 +6,12 @@ from blueice.likelihood import UnbinnedLogLikelihood as LogLikelihood
 
 
 def test_fit_minuit():
-    import iminuit
+    try:
+        import iminuit
+    except ImportError:
+        pytest.skip("Skipping iminuit tests, iminuit did not import")
     if not iminuit.__version__.startswith('1.'):
-        pytest.skip("Blueice's minuit wrappers assume minuit 1.x")
+        pytest.skip("Blueice's minuit wrappers assume iminuit 1.x")
 
     # Single rate parameter
     lf = LogLikelihood(test_conf())

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -12,7 +12,7 @@ def test_likelihood_value():
 
     # Make a single event at x=0
     lf.set_data(np.zeros(1,
-                         dtype=[('x', np.float), ('source', np.int)]))
+                         dtype=[('x', float), ('source', int)]))
 
     assert lf() == -1 + stats.norm.logpdf(0)
     assert lf(s0_rate_multiplier=2) == -2 + np.log(2 * stats.norm.pdf(0))
@@ -64,7 +64,7 @@ def test_rate_uncertainty():
 
     # Make a single event at x=0
     lf.set_data(np.zeros(1,
-                         dtype=[('x', np.float), ('source', np.int)]))
+                         dtype=[('x', float), ('source', int)]))
 
     log_prior = stats.norm(1, 0.5).logpdf
     assert lf() == -1 + stats.norm.logpdf(0) + log_prior(1)
@@ -85,7 +85,7 @@ def test_shape_uncertainty():
     # Make a single event at x=0
     lf.prepare()
     lf.set_data(np.zeros(1,
-                         dtype=[('x', np.float), ('source', np.int)]))
+                         dtype=[('x', float), ('source', int)]))
 
     log_prior = stats.norm(1, 0.5).logpdf
     assert lf() == -1 + stats.norm.logpdf(0) + log_prior(1)
@@ -152,7 +152,7 @@ def test_noninterpolated_pdf():
     lf.add_shape_parameter('sigma',(1.,2.))
     lf.prepare()
 
-    d = np.zeros(1,dtype=[('x',np.float)])
+    d = np.zeros(1,dtype=[('x',float)])
     lf.set_data(d)
 
     assert almost_equal(lf(compute_pdf=True,mu=0.5,sigma=1.5),sps.poisson(3).logpmf(1)+sps.norm(0.5,1.5).logpdf(0),1e-5)

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -7,7 +7,7 @@ import scipy.stats as sps
 
 def test_likelihood_value():
     """Just a sanity check to show we get the right likelihood values"""
-    lf = UnbinnedLogLikelihood(test_conf(events_per_day=1))
+    lf = UnbinnedLogLikelihood(conf_for_test(events_per_day=1))
     lf.add_rate_parameter('s0')
 
     # Make a single event at x=0
@@ -19,14 +19,14 @@ def test_likelihood_value():
 
 
 def test_no_shape_params():
-    lf = UnbinnedLogLikelihood(test_conf())
+    lf = UnbinnedLogLikelihood(conf_for_test())
     d = lf.base_model.simulate()
     lf.prepare()
     lf.set_data(d)
     lf()
 
     # Test a MonteCarloSource, which should trigger a pdf computation
-    lf = UnbinnedLogLikelihood(test_conf(mc=True))
+    lf = UnbinnedLogLikelihood(conf_for_test(mc=True))
     d = lf.base_model.simulate()
     lf.prepare()
     lf.set_data(d)
@@ -34,7 +34,7 @@ def test_no_shape_params():
 
 
 def test_shape_params():
-    lf = UnbinnedLogLikelihood(test_conf(n_sources=1))
+    lf = UnbinnedLogLikelihood(conf_for_test(n_sources=1))
     lf.add_rate_parameter('s0')
     with pytest.raises(InvalidParameterSpecification):
         lf.add_shape_parameter('strlen_multiplier', {1: 'x', 2: 'hi', 3:'wha'})
@@ -59,7 +59,7 @@ def test_shape_params():
 
 
 def test_rate_uncertainty():
-    lf = UnbinnedLogLikelihood(test_conf(events_per_day=1))
+    lf = UnbinnedLogLikelihood(conf_for_test(events_per_day=1))
     lf.add_rate_uncertainty('s0', 0.5)
 
     # Make a single event at x=0
@@ -72,7 +72,7 @@ def test_rate_uncertainty():
 
 
 def test_shape_uncertainty():
-    lf = UnbinnedLogLikelihood(test_conf(events_per_day=1))
+    lf = UnbinnedLogLikelihood(conf_for_test(events_per_day=1))
 
     with pytest.raises(InvalidParameterSpecification):
         lf.add_shape_uncertainty('strlen_multiplier', 0.5, {1: 'x', 2: 'hi', 3: 'wha'})
@@ -93,7 +93,7 @@ def test_shape_uncertainty():
 
 
 def test_multisource_likelihood():
-    lf = UnbinnedLogLikelihood(test_conf(n_sources=2))
+    lf = UnbinnedLogLikelihood(conf_for_test(n_sources=2))
 
     lf.add_shape_parameter('some_multiplier', (0.5, 1, 2, 4))
     lf.add_rate_parameter('s0')
@@ -120,7 +120,7 @@ def test_multisource_likelihood():
 
 
 def test_error_handling():
-    lf = UnbinnedLogLikelihood(test_conf())
+    lf = UnbinnedLogLikelihood(conf_for_test())
     d = lf.base_model.simulate()
     lf.add_shape_parameter('some_multiplier', (0.5, 1, 2))
 
@@ -145,7 +145,7 @@ def test_error_handling():
 def test_noninterpolated_pdf():
     #
 
-    conf = test_conf(n_sources=1)
+    conf = conf_for_test(n_sources=1)
     conf['some_multiplier']=3e-3
     lf = UnbinnedLogLikelihood(conf)
     lf.add_shape_parameter('mu',(0.,1.))

--- a/tests/test_likelihood_reparam.py
+++ b/tests/test_likelihood_reparam.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 
 def test_likelihood_value():
     """Just a sanity check to show we get the right likelihood values"""
-    config = test_conf_reparam(events_per_day=1)
+    config = conf_for_reparam_test(events_per_day=1)
     conv_config = deepcopy(BASE_CONV_CONFIG)
     # initialize the old likelihood first
     # this is an input for the reparameterized likelihood
@@ -23,7 +23,7 @@ def test_likelihood_value():
     lf_reparam = LogLikelihoodReParam(lf_old, conv_config)
 
     # dummy data
-    d = np.zeros(3, dtype=[('x', np.float), ('source', np.int)])
+    d = np.zeros(3, dtype=[('x', float), ('source', int)])
     lf_reparam.set_data(d)
 
     def compute_lf(np0=1, np1=1):
@@ -42,7 +42,7 @@ def test_likelihood_value():
 
 def test_likelihoods_before_after_reparam():
     """Compare the likelihood before and after reparameterization"""
-    config = test_conf_reparam(events_per_day=1)
+    config = conf_for_reparam_test(events_per_day=1)
     conv_config = deepcopy(BASE_CONV_CONFIG)
     # initialize the old likelihood first
     # this is an input for the reparameterized likelihood
@@ -75,7 +75,7 @@ def test_consistency_new_params(use_wrong_config=False, use_wrong_conv_config=Fa
     1) inside the conv_config
     2) between conv_config and config
     """
-    config = test_conf_reparam(events_per_day=1)
+    config = conf_for_reparam_test(events_per_day=1)
     conv_config = deepcopy(BASE_CONV_CONFIG)
 
     if use_wrong_config:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from blueice.test_helpers import *
 from blueice.model import Model
 
 def test_rates():
-    m = Model(test_conf(n_sources=1))
+    m = Model(conf_for_test(n_sources=1))
     np.testing.assert_array_equal(m.expected_events(), np.array([1000]))
 
     m.config['livetime_days'] = 2
@@ -19,7 +19,7 @@ def test_rates():
     m.config['some_multiplier'] = 1
 
     # Creating a new model, however, will do the trick:
-    conf = test_conf(n_sources=2)
+    conf = conf_for_test(n_sources=2)
     conf['some_multiplier'] = 2
     m = Model(conf)
     np.testing.assert_array_equal(m.expected_events(), np.array([2000, 2000]))
@@ -31,7 +31,7 @@ def test_rates():
     assert m.get_source('s1') == m.sources[1]
 
     # Test non-numeric settings
-    conf = test_conf(n_sources=1)
+    conf = conf_for_test(n_sources=1)
     conf['strlen_multiplier'] = 'hi'
     m = Model(conf)
     np.testing.assert_array_equal(m.expected_events(), np.array([2000]))

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -3,7 +3,7 @@ from blueice.model import Model
 
 
 def test_mcsource():
-    conf = test_conf(mc=True)
+    conf = conf_for_test(mc=True)
     m = Model(conf)
     s = m.sources[0]
     bins = conf['analysis_space'][0][1]


### PR DESCRIPTION
This is a temporary patch to resurrect the blueice tests:
  * Skip the iminuit test if a non-1.x series iminuit is installed, until #36 is fixed
  * Avoid the deprecated `np.float`, `np.int`, and `np.bool` aliases, see https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. This isn't a breaking problem yet, but causes quite a few warnings in numpy >= 1.20.