### PR TITLE
explicit unconditioned bf and -2llhr instead of just -llhr

### DIFF
--- a/blueice/inference.py
+++ b/blueice/inference.py
@@ -392,7 +392,7 @@ def one_parameter_interval(lf, target, bound,
 def plot_likelihood_ratio(lf, *space, vmax=15,
                           bestfit_routine=None,
                           plot_kwargs=None, **kwargs):
-    """Plots the - loglikelihood ratio derived from LogLikelihood lf in a parameter space
+    """Plots the -2loglikelihood ratio derived from LogLikelihood lf in a parameter space
     :param lf: LogLikelihood function with data set.
     :param space: list/tuple of tuples (dimname, points to plot)
     :param vmax: Limit for color bar (2d) or y axis (1d)
@@ -405,8 +405,9 @@ def plot_likelihood_ratio(lf, *space, vmax=15,
     if plot_kwargs is None:
         plot_kwargs = {}
 
+    best = bestfit_routine(lf, **kwargs)[1]
     results = []
-    label = "-Log likelihood ratio"
+    label = "-2Log likelihood ratio"
     if len(space) == 1:
         dim, x = space[0]
         for q in x:
@@ -414,8 +415,8 @@ def plot_likelihood_ratio(lf, *space, vmax=15,
             lf_kwargs.update(kwargs)
             results.append(bestfit_routine(lf, **lf_kwargs)[1])
         results = np.array(results)
-        results = results.max() - results
-        plt.plot(x, results, **plot_kwargs)
+        results = best - results
+        plt.plot(x, 2.*results, **plot_kwargs)
         plt.ylim(0, vmax)
         plt.ylabel(label)
         plt.xlabel(dim)
@@ -432,10 +433,8 @@ def plot_likelihood_ratio(lf, *space, vmax=15,
                 results[-1].append(bestfit_routine(lf, **lf_kwargs)[1])
         z1, z2 = np.meshgrid(x, y)
         results = np.array(results)
-        best = np.nanmax(results)
-        print(best)
         results = best - results
-        plt.pcolormesh(z1, z2, results.T, vmax=vmax, **plot_kwargs)
+        plt.pcolormesh(z1, z2, 2.*results.T, vmax=vmax, **plot_kwargs)
         plt.colorbar(label=label)
         plt.xlabel(dims[0])
         plt.ylabel(dims[1])


### PR DESCRIPTION
**Changes and motivation**
The changes in this pull request and their associated motivations are:
1. Explicitly computes the loglikelihood value at the unconditioned bestfit instead of just taking the max loglikelihood available in the scan range of the target parameter the user requested. In this way, even if the unconditioned bestfit is not within the scan range set by the user, the loglikelihood ratio will not be wrong.
2. Plots the -2 log likelihood ratio instead of the -log likelihood ratio so that it is easier to see if the resulting limit(s) is/are cutting at the anticipated values. [Wilks' theorem](https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-9/issue-1/The-Large-Sample-Distribution-of-the-Likelihood-Ratio-for-Testing/10.1214/aoms/1177732360.full) said that under certain asymptotic and regularity conditions, the -2log likelihood ratio follows the chi2 distribution of the appropriate number of degrees of freedom. Perhaps it is just convention but usually the critical value is for the -2 log likelihood ratio test statistic instead of the - log likelihood ratio test statistic and it would be easier for the user to overlay the profiled loglikelihood ratio and the critical value as a function of the target parameter if the y-axis is -2 loglikelihood ratio instead.
![m2llhr](https://github.com/JelleAalbers/blueice/assets/46324102/8bc419a9-4558-4f8c-9f34-14e1444a4dcb)

**Testing**
The [unit test](https://github.com/JelleAalbers/blueice/blob/2ab0d0f0fc9310b5faeccb7f863c3ea9d03dc7f7/tests/test_inference.py#L90-L106) that involves `plot_likelihood_ratio` was commented out because 'For now just test that it doesn't crash -- image comparison tests are tricky...'. To ensure that there are no breaking changes, the plot in the tutorial notebook was reproduced (but with -2 log likelihood ratio instead):
![image](https://github.com/JelleAalbers/blueice/assets/46324102/e46bb979-5c54-4cb5-bbd6-d169c7615bfd)
The first plot in this PR was also plotted using `plot_likelihood_ratio` from [this commit](https://github.com/JelleAalbers/blueice/commit/7882c726e3aa26bc14ce1a35fc79e8186f10e5a5).