### PR TITLE
Use scipy stats for PoissonLL

### DIFF
--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -10,7 +10,6 @@ from functools import wraps
 import numpy as np
 from multihist import Histdd
 from scipy import stats
-from scipy.special import gammaln
 from tqdm import tqdm
 
 from .exceptions import NotPreparedException, InvalidParameterSpecification, InvalidParameter
@@ -546,7 +545,7 @@ class BinnedLogLikelihood(LogLikelihoodBase):
 
         observed_counts = self.data_events_per_bin.histogram
 
-        ret = observed_counts * np.log(expected_total) - expected_total - gammaln(observed_counts + 1.).real
+        ret = stats.poisson(expected_total).logpmf(observed_counts)
         return np.sum(ret)
 
 

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -1,5 +1,5 @@
 from blueice.test_helpers import *
-from blueice.likelihood import UnbinnedLogLikelihood
+from blueice.likelihood import UnbinnedLogLikelihood, BinnedLogLikelihood
 from blueice.exceptions import NotPreparedException, InvalidParameterSpecification, InvalidParameter
 import pytest
 import scipy.stats as sps
@@ -157,3 +157,16 @@ def test_noninterpolated_pdf():
 
     assert almost_equal(lf(compute_pdf=True,mu=0.5,sigma=1.5),sps.poisson(3).logpmf(1)+sps.norm(0.5,1.5).logpdf(0),1e-5)
     assert not almost_equal(lf(compute_pdf=False,mu=0.5,sigma=1.5),sps.poisson(3).logpmf(1)+sps.norm(0.5,1.5).logpdf(0),1e-5)
+
+
+def test_zero_bin():
+    conf = conf_for_test(mc=True, analysis_space=[['x', [-40,40 ]]])
+
+    lf = BinnedLogLikelihood(conf)
+    lf.add_rate_parameter('s0')
+    lf.prepare()
+
+    # Make a single event at x=0
+    lf.set_data(np.zeros(0, dtype=[('x', float), ('source', int)]))
+
+    assert lf(s0_rate_multiplier=0.) == stats.poisson(0).logpmf(0)


### PR DESCRIPTION
I'm running into an edge case for the binned likelihood, where `np.log(expected_total)` throws an error when any of the expectations are zero. However, this is not problematic as long as the number of observed events in the same bins is zero. So instead of -inf or nan it makes sense to return 0 in this case.
Scipy stats has implemented this case accordingly, so I propose switching to this implementation.