### PR TITLE
Source-wise interpolation

### DIFF
--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -112,9 +112,12 @@ class LogLikelihoodBase:
 
     @property
     def source_shape_parameters(self):
+        """Dict of sources with shape parameters. source name -> dict of shape parameters."""
         source_shape_parameters = OrderedDict()
-        for sn, source_config in zip(self.source_name_list, self.pdf_base_config["sources"]):
-            parameter_names = source_config["parameters"]
+        for sn, source in zip(self.source_name_list, self.base_model.sources):
+            parameter_names = source.parameters
+            if parameter_names is None:
+                raise ValueError("The `parameters` of each source need to be specified when using `source_wise_interpolation`.")
             shape_parameters = OrderedDict({k: v for k, v in self.shape_parameters.items() if k in parameter_names})
             if shape_parameters:
                 source_shape_parameters[sn] = shape_parameters

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -115,10 +115,8 @@ class LogLikelihoodBase:
         """Dict of sources with shape parameters. source name -> dict of shape parameters."""
         source_shape_parameters = OrderedDict()
         for sn, source in zip(self.source_name_list, self.base_model.sources):
-            parameter_names = source.parameters
-            if parameter_names is None:
-                raise ValueError("The `parameters` of each source need to be specified when using `source_wise_interpolation`.")
-            shape_parameters = OrderedDict({k: v for k, v in self.shape_parameters.items() if k in parameter_names})
+            dont_hash_settings = source.config['dont_hash_settings']
+            shape_parameters = OrderedDict({k: v for k, v in self.shape_parameters.items() if k not in dont_hash_settings})
             if shape_parameters:
                 source_shape_parameters[sn] = shape_parameters
         return source_shape_parameters

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -152,11 +152,14 @@ class LogLikelihoodBase:
             if self.source_wise_interpolation:
                 # Create morphers for each source individually
                 self.source_morphers = OrderedDict()
-                for sn, shape_parameters in self.source_shape_parameters.items():
-                    self.source_morphers[sn] = MORPHERS[self.config['morpher']](
+
+                def create_source_morpher(shape_parameters):
+                    return MORPHERS[self.config['morpher']](
                         self.config.get('morpher_config', {}),
-                        shape_parameters
-                    )
+                        shape_parameters)
+
+                for sn, shape_parameters in self.source_shape_parameters.items():
+                    self.source_morphers[sn] = create_source_morpher(shape_parameters)
                 zs_list = set()
                 for source_name, morpher in self.source_morphers.items():
                     anchor_points = morpher.get_anchor_points(bounds=None)

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -120,10 +120,10 @@ class LogLikelihoodBase:
                 self.source_apply_efficiency,
                 self.source_efficiency_names
                 ):
-            ignore_parameters = source.config['dont_hash_settings']
+            ignore_parameters = set(source.config['dont_hash_settings'])
             # The efficiecny parameter doesn't need to be hashed but it needs to be passed to the morpher
             if apply_eff:
-                ignore_parameters.pop(eff_name, None)
+                ignore_parameters.discard(eff_name)
             shape_parameters = OrderedDict({k: v for k, v in self.shape_parameters.items() if k not in ignore_parameters})
             if shape_parameters:
                 source_shape_parameters[sn] = shape_parameters

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -588,16 +588,16 @@ class BinnedLogLikelihood(LogLikelihoodBase):
         if len(self.shape_parameters):
             if self.source_wise_interpolation:
                 raise NotImplementedError("Source-wise interpolation not implemented for binned likelihoods")
-            else:
-                self.ps_interpolator = self.morpher.make_interpolator(
-                    f=lambda m: m.pmf_grids()[0],
-                    extra_dims=list(self.ps.shape),
-                    anchor_models=self.anchor_models)
 
-                if self.model_statistical_uncertainty_handling is not None:
-                    self.n_model_events_interpolator = self.morpher.make_interpolator(f=lambda m: m.pmf_grids()[1],
-                                                                                    extra_dims=list(self.ps.shape),
-                                                                                    anchor_models=self.anchor_models)
+            self.ps_interpolator = self.morpher.make_interpolator(
+                f=lambda m: m.pmf_grids()[0],
+                extra_dims=list(self.ps.shape),
+                anchor_models=self.anchor_models)
+
+            if self.model_statistical_uncertainty_handling is not None:
+                self.n_model_events_interpolator = self.morpher.make_interpolator(f=lambda m: m.pmf_grids()[1],
+                                                                                extra_dims=list(self.ps.shape),
+                                                                                anchor_models=self.anchor_models)
 
     @inherit_docstring_from(LogLikelihoodBase)
     def set_data(self, d):

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -114,9 +114,17 @@ class LogLikelihoodBase:
     def source_shape_parameters(self):
         """Dict of sources with shape parameters. source name -> dict of shape parameters."""
         source_shape_parameters = OrderedDict()
-        for sn, source in zip(self.source_name_list, self.base_model.sources):
-            dont_hash_settings = source.config['dont_hash_settings']
-            shape_parameters = OrderedDict({k: v for k, v in self.shape_parameters.items() if k not in dont_hash_settings})
+        for sn, source, apply_eff, eff_name in zip(
+                self.source_name_list,
+                self.base_model.sources,
+                self.source_apply_efficiency,
+                self.source_efficiency_names
+                ):
+            ignore_parameters = source.config['dont_hash_settings']
+            # The efficiecny parameter doesn't need to be hashed but it needs to be passed to the morpher
+            if apply_eff:
+                ignore_parameters.pop(eff_name, None)
+            shape_parameters = OrderedDict({k: v for k, v in self.shape_parameters.items() if k not in ignore_parameters})
             if shape_parameters:
                 source_shape_parameters[sn] = shape_parameters
         return source_shape_parameters

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -155,7 +155,7 @@ class LogLikelihoodBase:
                         zs = self._get_model_anchor(anchor, source_name)
                         zs_list.add(zs)
                 zs_list = list(zs_list)
-                
+
             else:
                 self.morpher = MORPHERS[self.config['morpher']](self.config.get('morpher_config', {}),
                                                                 self.shape_parameters)
@@ -196,11 +196,10 @@ class LogLikelihoodBase:
                 models = [Model(c) for c in tqdm(configs, desc="Loading computed models")]
 
             if self.source_wise_interpolation:
-                print("USING SOURCE-WISE INTERPOLATION")
-                for i,(source_name, morpher) in enumerate(self.source_morphers.items()):
+                for i, (source_name, morpher) in enumerate(self.source_morphers.items()):
                     anchors = morpher.get_anchor_points(bounds=None)
                     self.anchor_sources[source_name] = OrderedDict()
-                    for anchor  in anchors:
+                    for anchor in anchors:
                         model_anchor = self._get_model_anchor(anchor, source_name)
                         model_index = zs_list.index(model_anchor)
                         self.anchor_sources[source_name][anchor] = models[model_index].sources[i]
@@ -213,6 +212,7 @@ class LogLikelihoodBase:
                             anchor_models=self.anchor_sources[sn])
                     else:
                         mus_interpolators[sn] = base_source.expected_events
+
                 def mus_interpolator(*args):
                     # take zs, convert to values for each source's interpolator call the respective interpolator
                     mus = []
@@ -232,9 +232,10 @@ class LogLikelihoodBase:
                     self.anchor_models[tuple(zs)] = model
 
                 # Build the interpolator for the rates of each source.
-                self.mus_interpolator = self.morpher.make_interpolator(f=lambda m: m.expected_events(),
-                                                                    extra_dims=[len(self.source_name_list)],
-                                                                    anchor_models=self.anchor_models)
+                self.mus_interpolator = self.morpher.make_interpolator(
+                    f=lambda m: m.expected_events(),
+                    extra_dims=[len(self.source_name_list)],
+                    anchor_models=self.anchor_models)
 
         self.is_data_set = False
         self.is_prepared = True
@@ -527,6 +528,7 @@ class UnbinnedLogLikelihood(LogLikelihoodBase):
                             anchor_models=self.anchor_sources[sn])
                     else:
                         ps_interpolators[sn] = base_source.pdf(*self.base_model.to_analysis_dimensions(d))
+
                 def ps_interpolator(*args):
                     # take zs, convert to values for each source's interpolator call the respective interpolator
                     ps = []
@@ -540,9 +542,10 @@ class UnbinnedLogLikelihood(LogLikelihoodBase):
                     return np.array(ps)
                 self.ps_interpolator = ps_interpolator
             else:
-                self.ps_interpolator = self.morpher.make_interpolator(f=lambda m: m.score_events(d),
-                                                                    extra_dims=[len(self.source_name_list), len(d)],
-                                                                    anchor_models=self.anchor_models)
+                self.ps_interpolator = self.morpher.make_interpolator(
+                    f=lambda m: m.score_events(d),
+                    extra_dims=[len(self.source_name_list), len(d)],
+                    anchor_models=self.anchor_models)
         else:
             self.ps = self.base_model.score_events(d)
 
@@ -575,9 +578,10 @@ class BinnedLogLikelihood(LogLikelihoodBase):
             if self.source_wise_interpolation:
                 raise NotImplementedError("Source-wise interpolation not implemented for binned likelihoods")
             else:
-                self.ps_interpolator = self.morpher.make_interpolator(f=lambda m: m.pmf_grids()[0],
-                                                                    extra_dims=list(self.ps.shape),
-                                                                    anchor_models=self.anchor_models)
+                self.ps_interpolator = self.morpher.make_interpolator(
+                    f=lambda m: m.pmf_grids()[0],
+                    extra_dims=list(self.ps.shape),
+                    anchor_models=self.anchor_models)
 
                 if self.model_statistical_uncertainty_handling is not None:
                     self.n_model_events_interpolator = self.morpher.make_interpolator(f=lambda m: m.pmf_grids()[1],

--- a/blueice/model.py
+++ b/blueice/model.py
@@ -106,11 +106,10 @@ class Model(object):
     def expected_events(self, s=None):
         """Return the total number of events expected in the analysis range for the source s.
         If no source specified, return an array of results for all sources.
-        # TODO: Why is this not a method of source?
         """
         if s is None:
             return np.array([self.expected_events(s) for s in self.sources])
-        return s.events_per_day * self.config['livetime_days'] * s.fraction_in_range * s.config['rate_multiplier']
+        return s.expected_events(self.config['livetime_days'])
 
     def show(self, d, ax=None, dims=None, **kwargs):
         """Plot the events from dataset d in the analysis range

--- a/blueice/model.py
+++ b/blueice/model.py
@@ -109,7 +109,7 @@ class Model(object):
         """
         if s is None:
             return np.array([self.expected_events(s) for s in self.sources])
-        return s.expected_events(self.config['livetime_days'])
+        return s.expected_events
 
     def show(self, d, ax=None, dims=None, **kwargs):
         """Plot the events from dataset d in the analysis range

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -86,6 +86,8 @@ class Source(object):
         self.name = c['name']
         del c['name']
 
+        self.parameters = c.pop('parameters', None)
+
         # events_per_day and fraction_in_range may be modified / set properly for the first time later (see comments
         # in 'defaults' above)
         if hasattr(self, 'events_per_day'):

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -86,8 +86,6 @@ class Source(object):
         self.name = c['name']
         del c['name']
 
-        self.parameters = c.pop('parameters', None)
-
         # events_per_day and fraction_in_range may be modified / set properly for the first time later (see comments
         # in 'defaults' above)
         if hasattr(self, 'events_per_day'):

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -261,6 +261,10 @@ class HistogramPdfSource(Source):
     def get_pmf_grid(self):
         return self._pdf_histogram.histogram * self._bin_volumes, self._n_events_histogram.histogram
 
+    def expected_events(self, livetime_days):
+        """Return the total number of events expected in the analysis range for the source."""
+        return self.events_per_day * livetime_days * self.fraction_in_range * self.config['rate_multiplier']
+
 
 class DensityEstimatingSource(HistogramPdfSource):
     """A source which estimates its PDF by some events you give to it.

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -182,6 +182,11 @@ class Source(object):
         if you decide some events are not detectable.
         """
         raise NotImplementedError
+    
+    @property
+    def expected_events(self):
+        """Return the default total number of events expected in the analysis range for the source."""
+        return self.events_per_day * self.config['livetime_days'] * self.fraction_in_range * self.config['rate_multiplier']
 
 
 class HistogramPdfSource(Source):
@@ -260,10 +265,6 @@ class HistogramPdfSource(Source):
 
     def get_pmf_grid(self):
         return self._pdf_histogram.histogram * self._bin_volumes, self._n_events_histogram.histogram
-
-    def expected_events(self, livetime_days):
-        """Return the total number of events expected in the analysis range for the source."""
-        return self.events_per_day * livetime_days * self.fraction_in_range * self.config['rate_multiplier']
 
 
 class DensityEstimatingSource(HistogramPdfSource):

--- a/blueice/source.py
+++ b/blueice/source.py
@@ -182,7 +182,7 @@ class Source(object):
         if you decide some events are not detectable.
         """
         raise NotImplementedError
-    
+
     @property
     def expected_events(self):
         """Return the default total number of events expected in the analysis range for the source."""

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -106,8 +106,6 @@ def test_source_wise_interpolation():
     ret_1 = lf(full_output=True, mu=1)
 
     config["source_wise_interpolation"] = True
-    # We need to specify all parameters used by each source
-    config["sources"][0]["parameters"] = ["mu", "sigma", "strlen_multiplier", "some_multiplier", "s0_rate_multiplier"]
     lf_source_wise = UnbinnedLogLikelihood(config)
     lf_source_wise.add_shape_parameter("mu", anchors={-2:-2, 0:0, 2:2})
     lf_source_wise.prepare()

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -92,6 +92,37 @@ def test_shape_uncertainty():
     assert lf(strlen_multiplier=2) == -2 + np.log(2 * stats.norm.pdf(0)) + log_prior(2)
 
 
+def test_source_wise_interpolation():
+    data = np.zeros(5, dtype=[('x', float), ('source', int)])
+    data['x'] = np.linspace(0, 1, 5)
+
+    config = conf_for_test(events_per_day=1)
+
+    lf = UnbinnedLogLikelihood(config)
+    lf.add_shape_parameter("mu", anchors={-2:-2, 0:0, 2:2})
+    lf.prepare()
+    lf.set_data(data)
+    ret_0 = lf(full_output=True)
+    ret_1 = lf(full_output=True, mu=1)
+
+    config["source_wise_interpolation"] = True
+    # We need to specify all parameters used by each source
+    config["sources"][0]["parameters"] = ["mu", "sigma", "strlen_multiplier", "some_multiplier", "s0_rate_multiplier"]
+    lf_source_wise = UnbinnedLogLikelihood(config)
+    lf_source_wise.add_shape_parameter("mu", anchors={-2:-2, 0:0, 2:2})
+    lf_source_wise.prepare()
+    lf_source_wise.set_data(data)
+    ret_source_wise_0 = lf_source_wise(full_output=True)
+    ret_source_wise_1 = lf_source_wise(full_output=True, mu=1)
+
+    assert ret_0[0] == ret_source_wise_0[0]
+    assert (ret_0[1] == ret_source_wise_0[1]).all()
+    assert (ret_0[2] == ret_source_wise_0[2]).all()
+    assert ret_1[0] == ret_source_wise_1[0]
+    assert (ret_1[1] == ret_source_wise_1[1]).all()
+    assert (ret_1[2] == ret_source_wise_1[2]).all()
+
+
 def test_multisource_likelihood():
     lf = UnbinnedLogLikelihood(conf_for_test(n_sources=2))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,9 +5,11 @@ def test_rates():
     m = Model(conf_for_test(n_sources=1))
     np.testing.assert_array_equal(m.expected_events(), np.array([1000]))
 
-    m.config['livetime_days'] = 2
+    for source in m.sources:
+        source.config['livetime_days'] = 2
     np.testing.assert_array_equal(m.expected_events(), np.array([2000]))
-    m.config['livetime_days'] = 1
+    for source in m.sources:
+        source.config['livetime_days'] = 1
 
     m.sources[0].fraction_in_range = 0.5
     np.testing.assert_array_equal(m.expected_events(), np.array([500]))


### PR DESCRIPTION
If I have two sources a and b in a model, each with two shape parameters s_a0, s_a1 and s_b0, s_b1, the interpolation of pdfs and expectation values currently happens on a 4D grid (s_a0, s_a1, s_b0, s_b1). This can quickly and unnecessarily blow up the required memory.

This PR adds source-wise interpolation. For this, we keep track of which source listens to which of the shape parameters and can thus interpolate on two 2D grids (s_a0, s_a1) and (s_b0, s_b1).

For now, I added this as an option so the default is unchanged.
So far, everything I tested seemed to work but I'll do more thorough checks in the next days.