### PR TITLE
PDF Interpolation: Cubic pchip

### DIFF
--- a/blueice/__init__.py
+++ b/blueice/__init__.py
@@ -7,5 +7,6 @@ from .source import *
 from .exceptions import *
 # from .inference import *   # Not needed, all the inference methods are added to LogLikelihood
 from .parallel import *
+from . import pdf_morphers_cubic  # registers CubicSplineInterpolator in MORPHERS
 
 __version__ = '1.2.1'

--- a/blueice/__init__.py
+++ b/blueice/__init__.py
@@ -7,6 +7,5 @@ from .source import *
 from .exceptions import *
 # from .inference import *   # Not needed, all the inference methods are added to LogLikelihood
 from .parallel import *
-from . import pdf_morphers_cubic  # registers CubicSplineInterpolator in MORPHERS
 
 __version__ = '1.2.1'

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -73,6 +73,7 @@ class LogLikelihoodBase:
             likelihood_config = {}
         self.config = likelihood_config
         self.config.setdefault('morpher', 'GridInterpolator')
+        self.config.setdefault('morpher_config', {'grid_interpolation_method': 'linear'})
         self.source_wise_interpolation = self.pdf_base_config.get('source_wise_interpolation', False)
 
         # Base model: no variations of any settings

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -15,9 +15,12 @@ from tqdm import tqdm
 from .exceptions import NotPreparedException, InvalidParameterSpecification, InvalidParameter
 from .model import Model
 from .parallel import create_models_ipyparallel, compute_many
-from .pdf_morphers import MORPHERS
 from .utils import combine_dicts, inherit_docstring_from
 from . import inference
+
+from .pdf_morphers import GridInterpolator, RadialInterpolator
+from .pdf_morphers_cubic import CubicSplineInterpolator
+MORPHERS = {x.__name__: x for x in [GridInterpolator, RadialInterpolator, CubicSplineInterpolator]}
 
 __all__ = ['LogLikelihoodBase', 'BinnedLogLikelihood', 'UnbinnedLogLikelihood', 'LogLikelihoodSum',
            'LogLikelihoodReParam']

--- a/blueice/likelihood.py
+++ b/blueice/likelihood.py
@@ -73,7 +73,6 @@ class LogLikelihoodBase:
             likelihood_config = {}
         self.config = likelihood_config
         self.config.setdefault('morpher', 'GridInterpolator')
-        self.config.setdefault('morpher_config', {'grid_interpolation_method': 'linear'})
         self.source_wise_interpolation = self.pdf_base_config.get('source_wise_interpolation', False)
 
         # Base model: no variations of any settings

--- a/blueice/pdf_morphers.py
+++ b/blueice/pdf_morphers.py
@@ -8,8 +8,7 @@ from tqdm import tqdm
 from .exceptions import NoShapeParameters
 from .utils import arrays_to_grid, inherit_docstring_from, combine_dicts
 
-__all__ = ['Morpher', 'GridInterpolator', 'RadialInterpolator',
-           'latin', 'MORPHERS']
+__all__ = ['Morpher', 'GridInterpolator', 'RadialInterpolator', 'latin']
 
 
 class Morpher(object):
@@ -191,6 +190,3 @@ def latin(n, d, box=None, shuffle_steps=500):
         pts[:, i] = box[i][0] + pts[:, i] * (box[i][1] - box[i][0])
 
     return pts
-
-
-MORPHERS = {x.__name__: x for x in [GridInterpolator, RadialInterpolator]}

--- a/blueice/pdf_morphers_cubic.py
+++ b/blueice/pdf_morphers_cubic.py
@@ -1,0 +1,150 @@
+"""C1-smooth, shape-preserving morpher using tensor-product PchipInterpolator.
+
+Fixes the C0 kink problem in GridInterpolator (linear RegularGridInterpolator).
+Shape preservation:  pchip is monotone between each pair of anchors.  If all
+anchor values are non-negative, the interpolated values are guaranteed non-negative.
+
+Activation in YAML
+------------------
+    likelihood_terms:
+      - name: sr2_far_wire
+        ...
+        likelihood_config:
+          morpher: CubicSplineInterpolator
+          morpher_config:
+            extrapolate: false   # default
+
+Config keys (morpher_config)
+----------------------------
+extrapolate : bool, default False
+    Whether to extrapolate beyond the outermost anchors.
+    Recommended False — extrapolation can produce negative values.
+"""
+
+import numpy as np
+from scipy.interpolate import PchipInterpolator
+
+from .pdf_morphers import GridInterpolator, MORPHERS
+from .utils import inherit_docstring_from
+
+
+def _make_fast_pchip_eval(x, extrapolate=False):
+    """Return a callable eval(xq, y) that evaluates pchip at scalar xq.
+
+    All x-dependent constants are pre-computed and closed over.
+    y shape: (n, ...) where axis 0 is the interpolation axis.
+    Returns array of shape y.shape[1:].
+    """
+    x = np.asarray(x, dtype=float)
+    h = np.diff(x)
+    hinv = 1.0 / h
+    n = len(x)
+
+    # Interior derivative weights (Fritsch-Carlson)
+    w1 = 2 * h[1:] + h[:-1]  
+    w2 = h[1:] + 2 * h[:-1]  
+
+    # Endpoint one-sided coefficients
+    ep0a = (2*h[0] + h[1]) / (h[0] + h[1])
+    ep0b = -h[0] / (h[0] + h[1])
+    epNa = (2*h[-1] + h[-2]) / (h[-1] + h[-2])
+    epNb = -h[-1] / (h[-1] + h[-2])
+
+    def eval_at(xq, y):
+        xq = float(xq)
+        nd = y.ndim
+        bcast = (slice(None),) + (np.newaxis,) * (nd - 1)
+
+        delta = np.diff(y, axis=0) * hinv[bcast]  # (n-1, ...)
+
+        d = np.empty_like(y)
+        d[0] = ep0a * delta[0] + ep0b * delta[1]
+        d[-1] = epNa * delta[-1] + epNb * delta[-2]
+
+        for k in range(1, n - 1):
+            ss = delta[k-1] * delta[k] > 0
+            with np.errstate(divide='ignore', invalid='ignore'):
+                d[k] = np.where(
+                    ss,
+                    (w1[k-1] + w2[k-1]) / (w1[k-1] / delta[k-1] + w2[k-1] / delta[k]),
+                    0.0,
+                )
+
+        # Clamp endpoints
+        d[0] = np.where(
+            np.sign(d[0]) != np.sign(delta[0]), 0.0,
+            np.where(np.abs(d[0]) > 3 * np.abs(delta[0]), 3 * delta[0], d[0]),
+        )
+        d[-1] = np.where(
+            np.sign(d[-1]) != np.sign(delta[-1]), 0.0,
+            np.where(np.abs(d[-1]) > 3 * np.abs(delta[-1]), 3 * delta[-1], d[-1]),
+        )
+
+        # Interval lookup
+        if extrapolate:
+            ki = np.clip(np.searchsorted(x, xq, side='right') - 1, 0, n - 2)
+        else:
+            ki = np.clip(np.searchsorted(x, xq, side='right') - 1, 0, n - 2)
+
+        t = (xq - x[ki]) / h[ki]
+        t2 = t * t
+        t3 = t2 * t
+        hk = h[ki]
+        return (
+            (2*t3 - 3*t2 + 1) * y[ki]
+            + (t3 - 2*t2 + t) * hk * d[ki]
+            + (-2*t3 + 3*t2) * y[ki+1]
+            + (t3 - t2) * hk * d[ki+1]
+        )
+
+    return eval_at
+
+
+class CubicSplineInterpolator(GridInterpolator):
+    """C1-smooth, shape-preserving morpher. Drop-in for GridInterpolator.
+
+    Uses pchip (monotone cubic Hermite) interpolation.  Guarantees non-negative
+    output when all anchor values are non-negative.  Eliminates the gradient kinks
+    that cause MIGRAD to produce invalid minima with linear interpolation.
+    """
+
+    @inherit_docstring_from(GridInterpolator)
+    def make_interpolator(self, f, extra_dims, anchor_models):
+        # Build anchor_scores exactly as GridInterpolator does.
+        # Shape: (n_1, n_2, ..., n_N, *extra_dims)
+        anchor_scores = np.zeros(
+            list(self.anchor_z_grid.shape)[:-1] + list(extra_dims)
+        )
+        for anchor_grid_index, _zs in self._anchor_grid_iterator():
+            anchor_scores[
+                tuple(anchor_grid_index + [slice(None)] * len(extra_dims))
+            ] = f(anchor_models[tuple(_zs)])
+
+        anchor_z_arrays = self.anchor_z_arrays
+        extrapolate = self.config.get('extrapolate', False)
+        n_dims = len(anchor_z_arrays)
+
+        # Axis 0: pre-build scipy PchipInterpolator once.
+        # Subsequent axes: use the fast numpy eval.
+        itp0 = PchipInterpolator(
+            anchor_z_arrays[0], anchor_scores, axis=0, extrapolate=extrapolate
+        )
+
+        if n_dims == 1:
+            return lambda zs: itp0(float(zs[0]))
+
+        fast_evals = [
+            _make_fast_pchip_eval(z_arr, extrapolate=extrapolate)
+            for z_arr in anchor_z_arrays[1:]
+        ]
+
+        def interpolator(zs):
+            current = itp0(float(zs[0]))
+            for z, fe in zip(zs[1:], fast_evals):
+                current = fe(float(z), current)
+            return current
+
+        return interpolator
+
+
+MORPHERS['CubicSplineInterpolator'] = CubicSplineInterpolator

--- a/blueice/pdf_morphers_cubic.py
+++ b/blueice/pdf_morphers_cubic.py
@@ -4,15 +4,27 @@ Fixes the C0 kink problem in GridInterpolator (linear RegularGridInterpolator).
 Shape preservation:  pchip is monotone between each pair of anchors.  If all
 anchor values are non-negative, the interpolated values are guaranteed non-negative.
 
-Activation in YAML
-------------------
+Activation
+----------
+In alea, set it in the likelihood term's YAML config:
+
     likelihood_terms:
-      - name: sr2_far_wire
+      - name: likelihood_name
         ...
         likelihood_config:
           morpher: CubicSplineInterpolator
           morpher_config:
             extrapolate: false   # default
+
+In plain blueice (no alea), pass the equivalent ``likelihood_config`` dict
+directly when constructing the likelihood, e.g.:
+
+    likelihood_config = {
+        ...
+        'morpher': 'CubicSplineInterpolator',
+        'morpher_config': {'extrapolate': False},  # default
+    }
+    ll = UnbinnedLogLikelihood(pdf_base_config, likelihood_config=likelihood_config)
 
 Config keys (morpher_config)
 ----------------------------

--- a/blueice/pdf_morphers_cubic.py
+++ b/blueice/pdf_morphers_cubic.py
@@ -36,7 +36,7 @@ extrapolate : bool, default False
 import numpy as np
 from scipy.interpolate import PchipInterpolator
 
-from .pdf_morphers import GridInterpolator, MORPHERS
+from .pdf_morphers import GridInterpolator
 from .utils import inherit_docstring_from
 
 
@@ -157,6 +157,3 @@ class CubicSplineInterpolator(GridInterpolator):
             return current
 
         return interpolator
-
-
-MORPHERS['CubicSplineInterpolator'] = CubicSplineInterpolator

--- a/tests/test_morphers.py
+++ b/tests/test_morphers.py
@@ -3,14 +3,14 @@ from collections import OrderedDict
 import blueice.exceptions
 import pytest
 import numpy as np
-from blueice import pdf_morphers
+from blueice import likelihood
 
 
 def test_morpher_api():
     conf = dict(hypercube_shuffle_steps=2,
                 r_sample_points=2)
 
-    for name, morph_class in pdf_morphers.MORPHERS.items():
+    for name, morph_class in likelihood.MORPHERS.items():
         print("Testing %s" % name)
 
         with pytest.raises(blueice.exceptions.NoShapeParameters):


### PR DESCRIPTION

Currently, the PDFs are interpolated between their anchor points using linear interpolation with RegularGridInterpolator. Linear interpolation is C0 and leads to the minuit minimizer struggling to find the minima near the anchor points. For complex likelihoods, these toys were observed to take about 70% more time than the toys that returned a "valid" minima. 

This PR proposes an alternative interpolation method using Piecewise Cubic Hermite Polynomials. For a nD likelihood, the implementation utilizes scipy's PchipInterpolator for the first axes and then uses numpy to implement the interpolation explicitly, reducing overhead. For the same complex likelihood above, the ratio of invalid minima reduced significantly leading to a significant improvement in the average time taken for fits. 

The one downside is that Pchip does not strictly conserve normalization between anchor points (see plot), but the maximum difference is of the order of 0.5%. Further study also shows that the best-fit results for both PoI and nuisance parameters agree between the proposed Pchip and current linear interpolations; suggesting that the original "invalid" minima were not genuinely invalid, and probably come from the minimizer struggling to realize that it is already close to the minima due to the discontinuity in the gradient. Hence, the major advantage from this change is the improved time overheads to run long sensitivity studies.

The default interpolation is still maintained as the linear interpolation. The new interpolation method can be activated by using the key:
`        
likelihood_config:
          morpher: CubicSplineInterpolator
          morpher_config:
            extrapolate: false   # default
`
in the likelihood config. 

<img width="698" height="567" alt="normalization_compare_projection" src="https://github.com/user-attachments/assets/7a4a0369-4217-4d26-a02f-91df6c9ee457" />

Detailed study with a Xenon likelihood: [Note (Xenon-Wiki)](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:analysis:analysts_overview_page:ananthakrishnan_ravindran:alea_blueice_fits:pdf_interpolation)